### PR TITLE
fix: collapse skin tone picker on blur

### DIFF
--- a/src/picker/components/Picker/Picker.html
+++ b/src/picker/components/Picker/Picker.html
@@ -53,19 +53,24 @@
          aria-label={i18n.skinTonesLabel}
          aria-activedescendant="skintone-{activeSkinTone}"
          aria-hidden={!skinTonePickerExpanded}
-         on:keydown={onSkinToneOptionKeydown}
-         on:click={onClickSkinToneOption}
+         on:focusout={onSkinToneOptionsFocusOut}
+         on:click={onSkinToneOptionsClick}
+         on:keydown={onSkinToneOptionsKeydown}
+         on:keyup={onSkinToneOptionsKeyup}
          bind:this={skinToneDropdown}>
       {#each skinTones as skinTone, i (skinTone)}
-        <button id="skintone-{i}"
-                class="emoji skintone-option hide-focus {i === activeSkinTone ? 'active' : ''}"
+        <!-- would use a button here, but iOS Safari misreports relatedTarget in that case, see issue #14 -->
+        <!-- see https://stackoverflow.com/a/42764495/680742 -->
+        <!-- see also https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus -->
+        <div    id="skintone-{i}"
+                class="emoji skintone-option cursor-pointer hide-focus {i === activeSkinTone ? 'active' : ''}"
                 aria-selected={i === activeSkinTone}
                 role="option"
                 title={i18n.skinTones[i]}
                 tabindex="-1"
                 aria-label={i18n.skinTones[i]}>
           {skinTone}
-        </button>
+        </div>
       {/each}
     </div>
 

--- a/src/picker/components/Picker/Picker.js
+++ b/src/picker/components/Picker/Picker.js
@@ -523,9 +523,9 @@ async function onEmojiClick (event) {
 //
 
 // eslint-disable-next-line no-unused-vars
-function onClickSkinToneOption (event) {
+async function onSkinToneOptionsClick (event) {
   const { target } = event
-  if (!target.classList.contains('emoji')) {
+  if (!target.classList.contains('skintone-option')) {
     return
   }
   halt(event)
@@ -561,9 +561,7 @@ $: {
 }
 
 // eslint-disable-next-line no-unused-vars
-function onSkinToneOptionKeydown (event) {
-  const { key } = event
-
+function onSkinToneOptionsKeydown (event) {
   if (!skinTonePickerExpanded) {
     return
   }
@@ -575,11 +573,38 @@ function onSkinToneOptionKeydown (event) {
     focus(`skintone-${activeSkinTone}`)
   }
 
-  switch (key) {
+  switch (event.key) {
     case 'ArrowUp':
       return goToNextOrPrevious(true)
     case 'ArrowDown':
       return goToNextOrPrevious(false)
+    case 'Enter':
+      // enter on keydown, space on keyup. this is just how browsers work for buttons
+      // https://lists.w3.org/Archives/Public/w3c-wai-ig/2019JanMar/0086.html
+      return onSkinToneOptionsClick(event)
+  }
+}
+
+// eslint-disable-next-line no-unused-vars
+function onSkinToneOptionsKeyup (event) {
+  if (!skinTonePickerExpanded) {
+    return
+  }
+  switch (event.key) {
+    case ' ':
+      // enter on keydown, space on keyup. this is just how browsers work for buttons
+      // https://lists.w3.org/Archives/Public/w3c-wai-ig/2019JanMar/0086.html
+      return onSkinToneOptionsClick(event)
+  }
+}
+
+// eslint-disable-next-line no-unused-vars
+async function onSkinToneOptionsFocusOut (event) {
+  // On blur outside of the skintone options, collapse the skintone picker.
+  // Except if focus is just moving to another skintone option, e.g. pressing up/down to change focus
+  const { relatedTarget } = event
+  if (!relatedTarget || !relatedTarget.classList.contains('skintone-option')) {
+    skinTonePickerExpanded = false
   }
 }
 

--- a/src/picker/styles/global.scss
+++ b/src/picker/styles/global.scss
@@ -50,3 +50,7 @@
 .no-pointer {
   pointer-events: none;
 }
+
+.cursor-pointer {
+  cursor: pointer;
+}

--- a/test/spec/picker/Picker.test.js
+++ b/test/spec/picker/Picker.test.js
@@ -314,7 +314,7 @@ describe('Picker tests', () => {
   }, 5000)
 
   // TODO: re-enable this behavior. See https://github.com/nolanlawson/emoji-picker-element/issues/14
-  test.skip('Closes skintone picker when blurred', async () => {
+  test('Closes skintone picker when blurred', async () => {
     fireEvent.click(getByRole('button', { name: /Choose a skin tone/ }))
     await waitFor(() => expect(getByRole('listbox', { name: 'Skin tones' })).toBeVisible())
     // Simulating a focusout event is hard, have to both focus and blur


### PR DESCRIPTION
fixes #16

I tested in all three engines in macOS and Ubuntu, as well as iOS Safari, macOS Safari VoiceOver, and NVDA Firefox on Windows. I tested blurring by clicking outside of the skin tone picker, as well as using both the mouse/touch and enter/spacebar to select the buttons. I learned a lot of somewhat arcane things about how browsers handle this stuff.

First off, `<button>`s behave differently in iOS Safari and Safari/Firefox on Mac. See https://stackoverflow.com/a/42764495/680742 and https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus and 

Second off, apparently the way buttons work is that Enter fires on keydown and spacebar fires on keyup. Because it wouldn't be the web if things weren't wildly unpredictable. :upside_down_face: https://lists.w3.org/Archives/Public/w3c-wai-ig/2019JanMar/0086.html

In any case, this seems to cover all cases, although I should probably test all 3 engines on Windows to be safest.