### PR TITLE
fix: tabs are not aria-selected in search mode

### DIFF
--- a/src/picker/components/Picker/Picker.html
+++ b/src/picker/components/Picker/Picker.html
@@ -80,7 +80,7 @@
               class="nav-button"
               aria-controls="tab-{group.id}"
               aria-label={i18n.categories[group.name]}
-              aria-selected={currentGroup.id === group.id}
+              aria-selected={!searchMode && currentGroup.id === group.id}
               title={i18n.categories[group.name]}
               on:click={() => onNavClick(group)}>
         <div class="emoji">

--- a/test/spec/picker/Picker.test.js
+++ b/test/spec/picker/Picker.test.js
@@ -65,12 +65,14 @@ describe('Picker tests', () => {
   })
 
   test('basic search test', async () => {
+    expect(queryAllByRole('tab', { selected: true })).toHaveLength(1) // one tab selected at first
     await type(getByRole('combobox'), 'monk')
 
     await waitFor(() => expect(getAllByRole('option')).toHaveLength(2))
 
     expect(getByRole('option', { name: /🐵/ })).toBeVisible()
     expect(getByRole('option', { name: /🐒/ })).toBeVisible()
+    expect(queryAllByRole('tab', { selected: true })).toHaveLength(0) // no tabs selected when searching
   })
 
   test('basic skintone test', async () => {


### PR DESCRIPTION
Just occurred to me that, when searching, these tabs should not be `aria-selected` because they don't have a visual indicator under them.