### PR TITLE
fix: fix aXe warning about aria-owns

### DIFF
--- a/src/picker/components/Picker/Picker.html
+++ b/src/picker/components/Picker/Picker.html
@@ -23,6 +23,7 @@
         spellcheck="true"
         aria-expanded={!!(searchMode && currentEmojis.length)}
         aria-controls="search-results"
+        aria-owns="search-results"
         aria-describedby="search-description"
         aria-autocomplete="list"
         aria-activedescendant={activeSearchItemId ? `emo-${activeSearchItemId}` : ''}


### PR DESCRIPTION
aXe has a warning about the combobox, because the listbox is not a child of the combobox. I'm using `aria-controls`, but adding `aria-owns` fixes this.

In VoiceOver and NVDA, it seems to make no difference either way, but we might as well get rid of the warning.