### PR TITLE
fix: fix axe warnings about aria-selected=""

### DIFF
--- a/src/picker/components/Picker/Picker.html
+++ b/src/picker/components/Picker/Picker.html
@@ -23,6 +23,7 @@
         spellcheck="true"
         aria-expanded={!!(searchMode && currentEmojis.length)}
         aria-controls="search-results"
+        aria-owns="search-results"
         aria-describedby="search-description"
         aria-autocomplete="list"
         aria-activedescendant={activeSearchItemId ? `emo-${activeSearchItemId}` : ''}
@@ -137,8 +138,8 @@
            id={searchMode ? 'search-results' : ''}
            use:calculateEmojiGridWidth>
         {#each emojiWithCategory.emojis as emoji, i (emoji.id)}
-          <button role={searchMode ? 'option' : 'menuitem'}
-                  aria-selected={searchMode ? i == activeSearchItem : ''}
+          <button {...(searchMode && {'aria-selected': i == activeSearchItem})}
+                  role={searchMode ? 'option' : 'menuitem'}
                   aria-label={labelWithSkin(emoji, currentSkinTone)}
                   title={emoji.title}
                   class="emoji {searchMode && i === activeSearchItem ? 'active' : ''}"


### PR DESCRIPTION
aXe warns because the `menuitem` elements have `aria-selected=""`. This doesn't seem to cause any issues in NVDA or VoiceOver, and fixing it bloats the bundle size by ~0.5kB with a lot of extra logic for doing the spread operator in Svelte. (Sadly, Svelte does not interpret `aria-selected=""` as "don't add this attribute entirely".)

I think the perf tradeoff here is not worth it. aXe is warning about an ARIA attribute that is effectively ignored because it doesn't apply to this element.