### PR TITLE
perf: use rollup-plugin-inject for smaller globals usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@babel/preset-env": "^7.10.2",
     "@peculiar/webcrypto": "^1.1.1",
     "@rollup/plugin-commonjs": "^11.1.0",
+    "@rollup/plugin-inject": "^4.0.2",
     "@rollup/plugin-node-resolve": "^7.1.3",
     "@rollup/plugin-replace": "^2.3.2",
     "@testing-library/dom": "^7.10.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,7 +6,10 @@ import hotSvelte from 'rollup-plugin-svelte-hot'
 import preprocess from 'svelte-preprocess'
 import analyze from 'rollup-plugin-analyzer'
 import cssnano from 'cssnano'
+import inject from '@rollup/plugin-inject'
+import path from 'path'
 
+const globals = path.resolve('./src/shared/globals.js')
 const dev = process.env.NODE_ENV !== 'production'
 const svelte = dev ? hotSvelte : mainSvelte
 
@@ -55,6 +58,14 @@ const baseConfig = {
       customElement: true,
       dev,
       preprocess: preprocessConfig
+    }),
+    // reduce the bundle size by using one import for certain globals
+    inject({
+      document: [globals, 'document'],
+      requestAnimationFrame: [globals, 'requestAnimationFrame'],
+      Map: [globals, 'Map'],
+      Promise: [globals, 'Promise'],
+      IDBKeyRange: [globals, 'IDBKeyRange']
     }),
     !dev && analyze({ summaryOnly: true })
   ],

--- a/src/database/customEmojiIndex.js
+++ b/src/database/customEmojiIndex.js
@@ -17,7 +17,7 @@ export function customEmojiIndex (customEmojis) {
   // search()
   //
   const emojiToTokens = emoji => (
-    [...new Set(emoji.shortcodes.map(shortcode => extractTokens(shortcode)).flat())]
+    [...Set(emoji.shortcodes.map(shortcode => extractTokens(shortcode)).flat())]
   )
   const searchTrie = trie(customEmojis, emojiToTokens)
   const searchByExactMatch = _ => searchTrie(_, true)
@@ -37,8 +37,8 @@ export function customEmojiIndex (customEmojis) {
   //
   // byShortcode, byName
   //
-  const shortcodeToEmoji = new Map()
-  const nameToEmoji = new Map()
+  const shortcodeToEmoji = Map()
+  const nameToEmoji = Map()
   for (const customEmoji of customEmojis) {
     nameToEmoji.set(customEmoji.name.toLowerCase(), customEmoji)
     for (const shortcode of customEmoji.shortcodes) {

--- a/src/database/utils/extractTokens.js
+++ b/src/database/utils/extractTokens.js
@@ -1,7 +1,7 @@
 // list of emoticons that don't match a simple \W+ regex
 // extracted using:
 // require('emojibase-data/en/data.json').map(_ => _.emoticon).filter(Boolean).filter(_ => !/^\W+$/.test(_))
-const irregularEmoticons = new Set([
+const irregularEmoticons = Set([
   ':D', 'xD', ":'D", 'o:)',
   ':x', ':p', ';p', 'xp',
   ':l', ':z', ':j', '8D',

--- a/src/database/utils/transformEmojiBaseData.js
+++ b/src/database/utils/transformEmojiBaseData.js
@@ -6,7 +6,7 @@ import { extractTokens } from './extractTokens'
 export function transformEmojiBaseData (emojiBaseData) {
   mark('transformEmojiBaseData')
   const res = emojiBaseData.map(({ annotation, emoticon, group, order, shortcodes, skins, tags, emoji, version }) => {
-    const tokens = [...new Set(
+    const tokens = [...Set(
       [
         ...shortcodes.map(extractTokens).flat(),
         ...tags.map(extractTokens).flat(),

--- a/src/database/utils/trie.js
+++ b/src/database/utils/trie.js
@@ -4,7 +4,7 @@
 const CODA_MARKER = '' // marks the end of the string
 
 export function trie (arr, itemToTokens) {
-  const map = new Map()
+  const map = Map()
   for (const item of arr) {
     const tokens = itemToTokens(item)
     for (const token of tokens) {
@@ -13,7 +13,7 @@ export function trie (arr, itemToTokens) {
         const char = token.charAt(i)
         let nextMap = currentMap.get(char)
         if (!nextMap) {
-          nextMap = new Map()
+          nextMap = Map()
           currentMap.set(char, nextMap)
         }
         currentMap = nextMap

--- a/src/picker/components/Picker/Picker.js
+++ b/src/picker/components/Picker/Picker.js
@@ -25,7 +25,6 @@ import { checkZwjSupport } from '../../utils/checkZwjSupport'
 import { requestPostAnimationFrame } from '../../utils/requestPostAnimationFrame'
 import { stop } from '../../../shared/marks'
 import { onMount, onDestroy, tick } from 'svelte'
-import { requestAnimationFrame } from '../../utils/requestAnimationFrame'
 import { uniq } from '../../../shared/uniq'
 
 // public
@@ -394,7 +393,7 @@ $: {
         }
       ]
     }
-    const categoriesToEmoji = new Map()
+    const categoriesToEmoji = Map()
     for (const emoji of currentEmojis) {
       const category = emoji.category || ''
       let emojis = categoriesToEmoji.get(category)

--- a/src/picker/utils/calculateWidth.js
+++ b/src/picker/utils/calculateWidth.js
@@ -2,8 +2,6 @@
 // using ResizeObserver. If ResizeObserver is unsupported, we just use rAF once
 // and don't bother to update.
 
-import { requestAnimationFrame } from './requestAnimationFrame'
-
 export const resizeObserverSupported = typeof ResizeObserver === 'function'
 
 export function calculateWidth (node, onUpdate) {

--- a/src/picker/utils/emojiSupport.js
+++ b/src/picker/utils/emojiSupport.js
@@ -9,7 +9,7 @@ export const emojiSupportLevelPromise = new Promise(resolve => (
 ))
 // determine which emojis containing ZWJ (zero width joiner) characters
 // are supported (rendered as one glyph) rather than unsupported (rendered as two or more glyphs)
-export const supportedZwjEmojis = new Map()
+export const supportedZwjEmojis = Map()
 
 if (process.env.NODE_ENV !== 'production') {
   emojiSupportLevelPromise.then(emojiSupportLevel => {

--- a/src/picker/utils/requestAnimationFrame.js
+++ b/src/picker/utils/requestAnimationFrame.js
@@ -1,4 +1,0 @@
-// import rAF from one place so that the bundle size is a bit smaller
-const rAF = requestAnimationFrame
-
-export { rAF as requestAnimationFrame }

--- a/src/picker/utils/requestPostAnimationFrame.js
+++ b/src/picker/utils/requestPostAnimationFrame.js
@@ -1,8 +1,6 @@
 // Measure after style/layout are complete
 // See https://github.com/andrewiggins/afterframe
 
-import { requestAnimationFrame } from './requestAnimationFrame'
-
 export const requestPostAnimationFrame = callback => {
   requestAnimationFrame(() => {
     setTimeout(callback)

--- a/src/shared/globals.js
+++ b/src/shared/globals.js
@@ -1,0 +1,17 @@
+// Putting all these globals in one place and referencing them with @rollup/plugin-inject
+// reduces the bundle size slightly (although increasing the compressed size a bit)
+
+const rAF = requestAnimationFrame
+export { rAF as requestAnimationFrame }
+
+const Prom = Promise
+export { Prom as Promise }
+
+const IDBKR = IDBKeyRange
+export { IDBKR as IDBKeyRange }
+
+const doc = document
+export { doc as document }
+
+const M = Map
+export { M as Map }

--- a/src/shared/uniqBy.js
+++ b/src/shared/uniqBy.js
@@ -1,6 +1,6 @@
 // like lodash's uniqBy but much smaller
 export function uniqBy (arr, func) {
-  const set = new Set()
+  const set = Set()
   const res = []
   for (const item of arr) {
     const key = func(item)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1099,6 +1099,15 @@
     magic-string "^0.25.2"
     resolve "^1.11.0"
 
+"@rollup/plugin-inject@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-inject/-/plugin-inject-4.0.2.tgz#55b21bb244a07675f7fdde577db929c82fc17395"
+  integrity sha512-TSLMA8waJ7Dmgmoc8JfPnwUwVZgLjjIAM6MqeIFqPO2ODK36JqE0Cf2F54UTgCUuW8da93Mvoj75a6KAVWgylw==
+  dependencies:
+    "@rollup/pluginutils" "^3.0.4"
+    estree-walker "^1.0.1"
+    magic-string "^0.25.5"
+
 "@rollup/plugin-node-resolve@^7.1.3":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.3.tgz#80de384edfbd7bfc9101164910f86078151a3eca"
@@ -1117,6 +1126,15 @@
   dependencies:
     "@rollup/pluginutils" "^3.0.8"
     magic-string "^0.25.5"
+
+"@rollup/pluginutils@^3.0.4":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
+  integrity sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==
+  dependencies:
+    "@types/estree" "0.0.39"
+    estree-walker "^1.0.1"
+    picomatch "^2.2.2"
 
 "@rollup/pluginutils@^3.0.8":
   version "3.0.10"


### PR DESCRIPTION
Related to #21, reduces minified size from 89.82kB to 39.77kB and the brotli size by 0.01kB.

Not sure if it's worth it, but it is a savings.