### PR TITLE
feat: add customCategorySort function

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Features:
   * [JavaScript API](#javascript-api)
     + [Picker](#picker)
       - [i18n structure](#i18n-structure)
+      - [Custom category order](#custom-category-order)
     + [Database](#database)
       - [Constructors](#constructors)
         * [constructor](#constructor)
@@ -232,7 +233,8 @@ The `new Picker(options)` constructor supports several options:
 
 Name | Type | Default | Description |
 ------ | ------ | ------ | ------ |
-`customEmoji` | CustomEmoji[] | - | Array of custom emoji  |
+`customCategorySort` | function | - | Function to sort custom category strings (sorted alphabetically by default)  |
+`customEmoji` | CustomEmoji[] | - | Array of custom emoji |
 `dataSource` | string | "https://cdn.jsdelivr.net/npm/emojibase-data@5/en/data.json" | URL to fetch the emojibase data from (`data-source` when used as an attribute) |
 `i18n` | I18n | - | i18n object (see below for details) |
 `locale` | string | "en" | Locale string |
@@ -318,6 +320,19 @@ Here is the default English `i18n` object (`"en"` locale):
 
 Note that some of these strings are only visible to users of screen readers.
 But you should still support them if you internationalize your app!
+
+#### Custom category order
+
+By default, custom categories are sorted alphabetically. To change this, pass in your own `customCategorySort`:
+
+```js
+picker.customCategorySort = (category1, category2) => { /* your sorting code */ };
+```
+
+This function should accept two strings and return a number.
+
+Custom emoji with no category will pass in `undefined`. By default, these are shown first, with the label `"Custom"`
+(determined by `i18n.categories.custom`).
 
 ### Database
 

--- a/src/picker/components/Picker/Picker.js
+++ b/src/picker/components/Picker/Picker.js
@@ -35,6 +35,7 @@ let skinToneEmoji = DEFAULT_SKIN_TONE_EMOJI
 let i18n = enI18n
 let database = null
 let customEmoji = null
+let customCategorySort = (a, b) => a < b ? -1 : a > b ? 1 : 0
 
 // private
 let initialLoad = true
@@ -406,7 +407,7 @@ $: {
     }
     return [...categoriesToEmoji.entries()]
       .map(([category, emojis]) => ({ category, emojis }))
-      .sort((a, b) => a.category < b.category ? -1 : 1)
+      .sort((a, b) => customCategorySort(a.category, b.category))
   }
 
   currentEmojisWithCategories = calculateCurrentEmojisWithCategories()
@@ -614,5 +615,6 @@ export {
   database,
   i18n,
   skinToneEmoji,
-  customEmoji
+  customEmoji,
+  customCategorySort
 }

--- a/src/types/picker.ts
+++ b/src/types/picker.ts
@@ -6,6 +6,7 @@ export default class Picker extends HTMLElement {
   i18n: I18n
   skinToneEmoji: string
   customEmoji?: CustomEmoji[]
+  customCategorySort?: (a: string, b: string) => number
 
   /**
    *
@@ -14,13 +15,15 @@ export default class Picker extends HTMLElement {
    * @param i18n - i18n object (see below for details)
    * @param skinToneEmoji - The emoji to use for the skin tone picker (`skin-tone-emoji` when used as an attribute)
    * @param customEmoji - Array of custom emoji
+   * @param customCategorySort - Function to sort custom category strings (sorted alphabetically by default)
    */
   constructor({
                 dataSource = 'https://cdn.jsdelivr.net/npm/emojibase-data@5/en/data.json',
                 locale = 'en',
                 i18n,
                 skinToneEmoji = '🖐️',
-                customEmoji
+                customEmoji,
+                customCategorySort
               }: PickerConstructorOptions = {}) {
     super()
   }

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -38,6 +38,7 @@ export interface PickerConstructorOptions {
   i18n?: I18n
   skinToneEmoji?: string
   customEmoji?: CustomEmoji[]
+  customCategorySort?: (a: string, b: string) => number
 }
 
 export interface I18n {

--- a/test/spec/utils.js
+++ b/test/spec/utils.js
@@ -1,0 +1,12 @@
+import * as testingLibrary from '@testing-library/dom'
+
+export async function getAccessibleName (container, node) {
+  let label = node.getAttribute('aria-label')
+  if (!label) {
+    const labeledBy = node.getAttribute('aria-labelledby')
+    if (labeledBy) {
+      label = testingLibrary.getNodeText(await container.getRootNode().getElementById(labeledBy))
+    }
+  }
+  return label
+}


### PR DESCRIPTION
Fixes #41

Adds the ability to define how you want custom categories to be sorted (default: alphabetical).