### PR TITLE
fix: rename customCategorySort to customCategorySorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ The `new Picker(options)` constructor supports several options:
 
 Name | Type | Default | Description |
 ------ | ------ | ------ | ------ |
-`customCategorySort` | function | - | Function to sort custom category strings (sorted alphabetically by default)  |
+`customCategorySorting` | function | - | Function to sort custom category strings (sorted alphabetically by default)  |
 `customEmoji` | CustomEmoji[] | - | Array of custom emoji |
 `dataSource` | string | "https://cdn.jsdelivr.net/npm/emojibase-data@5/en/data.json" | URL to fetch the emojibase data from (`data-source` when used as an attribute) |
 `i18n` | I18n | - | i18n object (see below for details) |
@@ -323,10 +323,10 @@ But you should still support them if you internationalize your app!
 
 #### Custom category order
 
-By default, custom categories are sorted alphabetically. To change this, pass in your own `customCategorySort`:
+By default, custom categories are sorted alphabetically. To change this, pass in your own `customCategorySorting`:
 
 ```js
-picker.customCategorySort = (category1, category2) => { /* your sorting code */ };
+picker.customCategorySorting = (category1, category2) => { /* your sorting code */ };
 ```
 
 This function should accept two strings and return a number.

--- a/src/picker/components/Picker/Picker.js
+++ b/src/picker/components/Picker/Picker.js
@@ -35,7 +35,7 @@ let skinToneEmoji = DEFAULT_SKIN_TONE_EMOJI
 let i18n = enI18n
 let database = null
 let customEmoji = null
-let customCategorySort = (a, b) => a < b ? -1 : a > b ? 1 : 0
+let customCategorySorting = (a, b) => a < b ? -1 : a > b ? 1 : 0
 
 // private
 let initialLoad = true
@@ -407,7 +407,7 @@ $: {
     }
     return [...categoriesToEmoji.entries()]
       .map(([category, emojis]) => ({ category, emojis }))
-      .sort((a, b) => customCategorySort(a.category, b.category))
+      .sort((a, b) => customCategorySorting(a.category, b.category))
   }
 
   currentEmojisWithCategories = calculateCurrentEmojisWithCategories()
@@ -616,5 +616,5 @@ export {
   i18n,
   skinToneEmoji,
   customEmoji,
-  customCategorySort
+  customCategorySorting
 }

--- a/src/types/picker.ts
+++ b/src/types/picker.ts
@@ -6,7 +6,7 @@ export default class Picker extends HTMLElement {
   i18n: I18n
   skinToneEmoji: string
   customEmoji?: CustomEmoji[]
-  customCategorySort?: (a: string, b: string) => number
+  customCategorySorting?: (a: string, b: string) => number
 
   /**
    *
@@ -15,7 +15,7 @@ export default class Picker extends HTMLElement {
    * @param i18n - i18n object (see below for details)
    * @param skinToneEmoji - The emoji to use for the skin tone picker (`skin-tone-emoji` when used as an attribute)
    * @param customEmoji - Array of custom emoji
-   * @param customCategorySort - Function to sort custom category strings (sorted alphabetically by default)
+   * @param customCategorySorting - Function to sort custom category strings (sorted alphabetically by default)
    */
   constructor({
                 dataSource = 'https://cdn.jsdelivr.net/npm/emojibase-data@5/en/data.json',
@@ -23,7 +23,7 @@ export default class Picker extends HTMLElement {
                 i18n,
                 skinToneEmoji = '🖐️',
                 customEmoji,
-                customCategorySort
+                customCategorySorting
               }: PickerConstructorOptions = {}) {
     super()
   }

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -38,7 +38,7 @@ export interface PickerConstructorOptions {
   i18n?: I18n
   skinToneEmoji?: string
   customEmoji?: CustomEmoji[]
-  customCategorySort?: (a: string, b: string) => number
+  customCategorySorting?: (a: string, b: string) => number
 }
 
 export interface I18n {

--- a/test/spec/picker/Picker.test.js
+++ b/test/spec/picker/Picker.test.js
@@ -419,7 +419,7 @@ describe('Picker tests', () => {
     ])
 
     const order = ['Ungulates', 'Primates', 'Avians']
-    picker.customCategorySort = (a, b) => {
+    picker.customCategorySorting = (a, b) => {
       const aIdx = order.indexOf(a)
       const bIdx = order.indexOf(b)
       return aIdx < bIdx ? -1 : 1


### PR DESCRIPTION
Related to #41. I thought about it, and I like this name better.

MDN calls it a [compareFunction](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort), but I think `customCategoryCompareFunction` is too wordy. And yet, `sort` is weird because it's not a noun. `sorting` is slightly wordier, but feels better to me. Naming things is hard.

Not a breaking change because we haven't had a release yet.