### PR TITLE
Convert .ts to .d.ts files

### DIFF
--- a/src/types/picker.ts
+++ b/src/types/picker.ts
@@ -28,15 +28,13 @@ export default class Picker extends HTMLElement {
     super()
   }
 
-  // Adding types for addEventListener is hard... I basically just copy-pasted this from lib.dom.d.ts. Not sure
-  // Why I need the @ts-ignore
-  addEventListener<K extends keyof EmojiPickerEventMap>(type: K, listener: (this: TextTrackCue, ev: EmojiPickerEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void
-  // @ts-ignore
-  addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void
+  addEventListener<K extends keyof EmojiPickerEventMap>(type: K, listener: (this: Picker, ev: EmojiPickerEventMap[K]) => any, options?: boolean | AddEventListenerOptions) {
+    super.addEventListener(type, listener, options);
+  }
 
-  removeEventListener<K extends keyof EmojiPickerEventMap>(type: K, listener: (this: TextTrackCue, ev: EmojiPickerEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void
-  // @ts-ignore
-  removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void
+  removeEventListener<K extends keyof EmojiPickerEventMap>(type: K, listener: (this: Picker, ev: EmojiPickerEventMap[K]) => any, options?: boolean | EventListenerOptions) {
+    super.removeEventListener(type, listener, options);
+  }
 }
 
 // see https://justinfagnani.com/2019/11/01/how-to-publish-web-components-to-npm/


### PR DESCRIPTION
Good evening,

Some days ago I found out, that the picker types don't have a signature for `removeEventListener`, so I was about to create an issue. But then I though "Why don't you fix that?". Then I saw your types and the dummy classes and five shaved yaks later I'm here. (Yes I read the contribution guidelines.)

This PR:
- Converts all .ts files to .d.ts files and removes the dummy implementations.
- Gets rid of `@ts-ignore` 
- Changes the typedoc call to also include the .d.ts files
- Changes the generateTOC script, so it still finds the scripts
- Add signatures for removeEventListener

Feel free to review!