### PR TITLE
fix: use consistent HTML for custom emoji

### DIFF
--- a/src/picker/components/Picker/Picker.html
+++ b/src/picker/components/Picker/Picker.html
@@ -147,9 +147,7 @@
             {#if emoji.unicode}
               {unicodeWithSkin(emoji, currentSkinTone)}
             {:else}
-              <div class="custom-emoji"
-                   style="background-image: url({emoji.url});"
-              />
+              <div class="custom-emoji" style="background-image: url({emoji.url});"/>
             {/if}
           </button>
         {/each}
@@ -175,11 +173,7 @@
         {#if emoji.unicode}
           {unicodeWithSkin(emoji, currentSkinTone)}
         {:else}
-          <img class="custom-emoji"
-               src={emoji.url}
-               loading="lazy"
-               alt=""
-          />
+          <div class="custom-emoji" style="background-image: url({emoji.url});"/>
         {/if}
       </button>
     {/each}


### PR DESCRIPTION
Dunno how I missed this, but the favorites bar was rendering custom emoji as `<img>`s whereas elsewhere it's a `<div>`. Should be consistent about this.

Also I tested `loading=lazy` but didn't really seem to work well in Chrome. Maybe worth re-evaluating now that Firefox has it too.