### PR TITLE
perf: use lazy image loading

### DIFF
--- a/src/picker/components/Picker/Picker.html
+++ b/src/picker/components/Picker/Picker.html
@@ -147,7 +147,7 @@
             {#if emoji.unicode}
               {unicodeWithSkin(emoji, currentSkinTone)}
             {:else}
-              <div class="custom-emoji" style="background-image: url({emoji.url});"/>
+              <img class="custom-emoji" src={emoji.url} alt="" loading="lazy" />
             {/if}
           </button>
         {/each}
@@ -173,7 +173,7 @@
         {#if emoji.unicode}
           {unicodeWithSkin(emoji, currentSkinTone)}
         {:else}
-          <div class="custom-emoji" style="background-image: url({emoji.url});"/>
+          <img class="custom-emoji" src={emoji.url} alt="" loading="lazy" />
         {/if}
       </button>
     {/each}


### PR DESCRIPTION
Testing in Chrome, this works quite well. As you scroll, custom emoji are loaded lazily.

In Firefox, it doesn't work well at all, but this is no worse than the status quo of loading all images eagerly at once. Probably FF needs to tweak their algorithm for inner scrollers as opposed to document scrollers.

Safari does not support this yet but it's behind a flag.

For the favorites bar it doesn't matter much since the favorites bar is always visible. But I keep it for consistency and because maybe people have the emoji-picker in a place where it's not immediately visible, so lazy-loading makes sense in that case.