### PR TITLE
fix: remove unnecessary aria-hidden

### DIFF
--- a/src/picker/components/Picker/Picker.html
+++ b/src/picker/components/Picker/Picker.html
@@ -95,8 +95,7 @@
       </button>
     {/each}
   </div>
-  <div class="indicator-wrapper"
-       aria-hidden="true">
+  <div class="indicator-wrapper">
     <div class="indicator"
          style={indicatorStyle}
          use:calculateIndicatorWidth>


### PR DESCRIPTION
There's no text or images inside of this node, so no need for aria-hidden.