### PR TITLE
fix: emoticon is not a required field

### DIFF
--- a/src/database/utils/requiredKeys.js
+++ b/src/database/utils/requiredKeys.js
@@ -1,7 +1,6 @@
 export const requiredKeys = [
   'annotation',
   'emoji',
-  'emoticon',
   'group',
   'order',
   'shortcodes',


### PR DESCRIPTION
`emoticon` was never required. It's already listed in the `optionalKeys` in `trimEmojiData.js` anyway