### PR TITLE
fix: fix race condition on custom emoji

### DIFF
--- a/src/picker/components/Picker/Picker.js
+++ b/src/picker/components/Picker/Picker.js
@@ -301,11 +301,19 @@ $: {
       currentEmojis = []
       searchMode = false
     } else if (searchText.length >= MIN_SEARCH_TEXT_LENGTH) {
-      currentEmojis = await getEmojisBySearchQuery(searchText)
-      searchMode = true
+      const currentSearchText = searchText
+      const newEmojis = await getEmojisBySearchQuery(currentSearchText)
+      if (currentSearchText === searchText) { // if the situation changes asynchronously, do not update
+        currentEmojis = newEmojis
+        searchMode = true
+      }
     } else if (currentGroup) {
-      currentEmojis = await getEmojisByGroup(currentGroup.id)
-      searchMode = false
+      const currentGroupId = currentGroup.id
+      const newEmojis = await getEmojisByGroup(currentGroupId)
+      if (currentGroupId === currentGroup.id) { // if the situation changes asynchronously, do not update
+        currentEmojis = newEmojis
+        searchMode = false
+      }
     }
   }
   /* no await */ updateEmojis()

--- a/test/spec/picker/custom.test.js
+++ b/test/spec/picker/custom.test.js
@@ -1,0 +1,34 @@
+import { ALL_EMOJI, basicBeforeEach, tick } from '../shared'
+import { groups } from '../../../src/picker/groups'
+import Picker from '../../../src/picker/PickerElement'
+import { getAllByRole, getByRole, waitFor } from '@testing-library/dom'
+
+describe('Custom emojis tests', () => {
+  beforeEach(basicBeforeEach)
+
+  test('Setting custom emoji shows the proper first page', async () => {
+    const picker = new Picker({
+      locale: 'en',
+      dataSource: ALL_EMOJI
+    })
+    picker.customEmoji = [
+      {
+        name: 'monkey',
+        shortcodes: ['monkey'],
+        url: 'monkey.png'
+      }
+    ]
+    document.body.appendChild(picker)
+
+    const container = picker.shadowRoot.querySelector('.picker')
+
+    await waitFor(() => expect(getAllByRole(container, 'tab')).toHaveLength(groups.length + 1))
+
+    // We actually have to sleep here, because we want to test for a race condition where the
+    // custom emoji show first, but then are replaced by the non-custom emoji
+    // https://github.com/nolanlawson/emoji-picker-element/issues/84
+    await tick(50)
+
+    await waitFor(() => expect(getByRole(container, 'menuitem', { name: 'monkey' })).toBeVisible())
+  })
+})


### PR DESCRIPTION
Not sure this is really testable, because it only manifests when IndexedDB takes a while to return. I think fakeIndexedDB just returns in the same turn of the event loop, so we may not be able to catch it. But in any case, this is the fix.

Fixes #84 