### PR TITLE
perf: avoid full DB scan for 1-char shortcodes

### DIFF
--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -1,2 +1,2 @@
-export const MIN_SEARCH_TEXT_LENGTH = 2
+export const MIN_SEARCH_TEXT_LENGTH = 1
 export const NUM_SKIN_TONES = 6

--- a/test/spec/database/getEmojiBySearchQuery.test.js
+++ b/test/spec/database/getEmojiBySearchQuery.test.js
@@ -195,4 +195,14 @@ describe('getEmojiBySearchQuery', () => {
     expect((await db.getEmojiBySearchQuery(';;;;'))).toStrictEqual([])
     expect((await db.getEmojiBySearchQuery('B&'))).toStrictEqual([])
   })
+
+  test('very short search query', async () => {
+    const db = new Database({ dataSource: ALL_EMOJI })
+    expect((await db.getEmojiBySearchQuery('v')).map(_ => _.annotation))
+      .toStrictEqual([
+        'vulcan salute', 'victory hand',
+        'tomato', 'volcano',
+        'moon viewing ceremony', 'safety vest']
+      )
+  })
 })


### PR DESCRIPTION
Alternative implementation to https://github.com/nolanlawson/emoji-picker-element/pull/91 , decreasing the min search query length from 2 to 1.

Need to run some tests to see how this compares, but let's see if the tests pass.

Should avoid the storage increase while also fixing the full DB scan issue when searching for `v` or `doesnotexist`.

Not sure if this warrants busting the cache to force a reindex of the emoji data.