### PR TITLE
perf: use batch cursor for full DB scan

### DIFF
--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
   "bundlesize": [
     {
       "path": "./bundle.js",
-      "maxSize": "41 kB",
+      "maxSize": "41.5 kB",
       "compression": "none"
     },
     {


### PR DESCRIPTION
Yet another alternative to #91 and #93. Just replaces the current single-item cursor with a batched cursor.

Perf improves from ~400ms to ~150ms using the benchmark described in the code comments, and nothing about the DB structure had to change. The code size did grow a slight amount.