### PR TITLE
perf: simplify baseline emoji html

### DIFF
--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
   "bundlesize": [
     {
       "path": "./bundle.js",
-      "maxSize": "41.5 kB",
+      "maxSize": "41.1 kB",
       "compression": "none"
     },
     {

--- a/src/picker/components/Picker/Picker.html
+++ b/src/picker/components/Picker/Picker.html
@@ -177,7 +177,6 @@
       </button>
     {/each}
   </div>
-  <div aria-hidden="true" class="hidden abs-pos">
-    <button tabindex="-1" class="emoji baseline-emoji" bind:this={baselineEmoji}>😀</button>
-  </div>
+  <!-- This serves as a baseline emoji for measuring against and determining emoji support -->
+  <button aria-hidden="true" tabindex="-1" class="abs-pos hidden emoji" bind:this={baselineEmoji}>😀</button>
 </section>


### PR DESCRIPTION
Simplifies some HTML that doesn't need to be so verbose, dropping the bundle size a bit.