### PR TITLE
fix: fix getEmojiByShortcode when shortcodes are optional

### DIFF
--- a/src/database/idbInterface.js
+++ b/src/database/idbInterface.js
@@ -172,7 +172,7 @@ export async function getEmojiByShortcode (db, shortcode) {
   }
 
   return emojis.filter(_ => {
-    const lowerShortcodes = _.shortcodes.map(_ => _.toLowerCase())
+    const lowerShortcodes = (_.shortcodes || []).map(_ => _.toLowerCase())
     return lowerShortcodes.includes(shortcode.toLowerCase())
   })[0] || null
 }

--- a/test/spec/database/custom.test.js
+++ b/test/spec/database/custom.test.js
@@ -228,4 +228,17 @@ describe('custom emoji', () => {
     )
     expect(await db.getEmojiByUnicodeOrName('unknown')).toBeNull()
   })
+
+  test('shortcodes are optional in custom emoji', async () => {
+    const customs = JSON.parse(JSON.stringify(customEmojis))
+    for (const custom of customs) {
+      if (!custom.shortcodes.includes('monkey')) {
+        delete custom.shortcodes
+      }
+    }
+    db.customEmoji = customs
+
+    expect((await db.getEmojiByShortcode('monkey')).name).toEqual('monkey')
+    expect(await db.getEmojiByShortcode('a')).toEqual(null)
+  })
 })

--- a/test/spec/database/custom.test.js
+++ b/test/spec/database/custom.test.js
@@ -240,5 +240,6 @@ describe('custom emoji', () => {
 
     expect((await db.getEmojiByShortcode('monkey')).name).toEqual('monkey')
     expect(await db.getEmojiByShortcode('a')).toEqual(null)
+    expect(await db.getEmojiByShortcode('doesnotexist')).toEqual(null)
   })
 })

--- a/test/spec/database/getEmojiByShortcode.test.js
+++ b/test/spec/database/getEmojiByShortcode.test.js
@@ -40,6 +40,8 @@ describe('getEmojiByShortcode', () => {
         expect((await db.getEmojiByShortcode(shortcode.toUpperCase())).unicode).toEqual(emoji.emoji)
       }
     }
+
+    await db.delete()
   })
 
   test('short nonexistent shortcodes', async () => {
@@ -48,5 +50,28 @@ describe('getEmojiByShortcode', () => {
     expect(await db.getEmojiByShortcode('z')).toEqual(null)
     expect(await db.getEmojiByShortcode('1')).toEqual(null)
     expect(await db.getEmojiByShortcode(' ')).toEqual(null)
+
+    await db.delete()
+  })
+
+  test('works although shortcodes are optional', async () => {
+    const dataSource = 'http://localhost/shortcodes-optional.json'
+    const emojis = JSON.parse(JSON.stringify(truncatedEmoji))
+    for (const emoji of emojis) {
+      if (!emoji.shortcodes.includes('dog_face')) {
+        delete emoji.shortcodes
+      }
+    }
+
+    fetch
+      .get(dataSource, () => new Response(JSON.stringify(emojis), { headers: { ETag: 'W/optional' } }))
+      .head(dataSource, () => new Response(null, { headers: { ETag: 'W/optional' } }))
+
+    const db = new Database({ dataSource })
+
+    expect((await db.getEmojiByShortcode('dog_face')).unicode).toEqual('🐶')
+    expect(await db.getEmojiByShortcode('monkey_face')).toEqual(null)
+
+    await db.delete()
   })
 })

--- a/test/spec/database/getEmojiByShortcode.test.js
+++ b/test/spec/database/getEmojiByShortcode.test.js
@@ -71,6 +71,7 @@ describe('getEmojiByShortcode', () => {
 
     expect((await db.getEmojiByShortcode('dog_face')).unicode).toEqual('🐶')
     expect(await db.getEmojiByShortcode('monkey_face')).toEqual(null)
+    expect(await db.getEmojiByShortcode('doesnotexist')).toEqual(null)
 
     await db.delete()
   })


### PR DESCRIPTION
fixes a bug in `getEmojiByShortcode` when native emoji don't have any shortcodes (e.g. English github shortcode set).