### PR TITLE
chore: use jest --runInBand for better CircleCI perf

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
     "dev:server": "node ./test/adhoc/server.js",
     "lint": "standard && stylelint '**/*.scss'",
     "lint:fix": "standard --fix && stylelint --fix '**/*.scss'",
-    "test": "jest",
+    "test": "jest --runInBand",
     "test:adhoc": "node ./test/adhoc/server.js",
-    "cover": "jest --coverage",
+    "cover": "jest --runInBand --coverage",
     "docs": "node bin/processCustomEmoji.js",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",
     "version": "run-s changelog docs && git add CHANGELOG.md docs"


### PR DESCRIPTION
Tests are failing in CI due to out of memory errors, apparently this helps: https://jestjs.io/docs/en/troubleshooting#tests-are-extremely-slow-on-docker-andor-continuous-integration-ci-server