### PR TITLE
feat: allow styling category emoji separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Here is a full list of options:
 | `--num-columns`              | `8`                    |                | How many columns to display in the emoji grid                                                        |
 | `--outline-color`            | `#999`                 | `#fff`         | Focus outline color                                                                                  |
 | `--outline-size`             | `2px`                  |                | Focus outline width                                                                                  |
-| `--skintone-border-radius`   | `1rem`                 |                | border radius of the skintone dropdown                                                               |
+| `--skintone-border-radius`   | `1rem`                 |                | Border radius of the skintone dropdown                                                               |
 
 <!-- CSS variable options end -->
 

--- a/README.md
+++ b/README.md
@@ -179,33 +179,33 @@ Here is a full list of options:
 
 <!-- CSS variable options start -->
 
-| Variable                     | Default                | Default (dark) | Description                                                                                                   |
-| ---------------------------- | ---------------------- | -------------- | ------------------------------------------------------------------------------------------------------------- |
-| `--background`               | `#fff`                 | `#222`         | Background of the entire `<emoji-picker>`                                                                     |
-| `--border-color`             | `#e0e0e0`              | `#444`         |                                                                                                               |
-| `--border-size`              | `1px`                  |                | Width of border used in most of the picker                                                                    |
-| `--button-active-background` | `#e6e6e6`              | `#555555`      | Background of an active button                                                                                |
-| `--button-hover-background`  | `#d9d9d9`              | `#484848`      | Background of a hovered button                                                                                |
-| `--category-emoji-padding`   | `var(--emoji-padding)` |                | Vertical/horizontal padding on category emoji, if you want it to be different from `--category-emoji-padding` |
-| `--category-emoji-size`      | `var(--emoji-size)`    |                | Width/height of category emoji, if you want it to be different from `--emoji-size`                            |
-| `--category-font-color`      | `#111`                 | `#efefef`      | Font color of custom emoji category headings                                                                  |
-| `--category-font-size`       | `1rem`                 |                | Font size of custom emoji category headings                                                                   |
-| `--emoji-padding`            | `0.5rem`               |                | Vertical and horizontal padding on emoji                                                                      |
-| `--emoji-size`               | `1.375rem`             |                | Width and height of all emoji                                                                                 |
-| `--indicator-color`          | `#385ac1`              | `#5373ec`      | Color of the nav indicator                                                                                    |
-| `--indicator-height`         | `3px`                  |                | Height of the nav indicator                                                                                   |
-| `--input-border-color`       | `#999`                 | `#ccc`         |                                                                                                               |
-| `--input-border-radius`      | `0.5rem`               |                |                                                                                                               |
-| `--input-border-size`        | `1px`                  |                |                                                                                                               |
-| `--input-font-color`         | `#111`                 | `#efefef`      |                                                                                                               |
-| `--input-font-size`          | `1rem`                 |                |                                                                                                               |
-| `--input-line-height`        | `1.5`                  |                |                                                                                                               |
-| `--input-padding`            | `0.25rem`              |                |                                                                                                               |
-| `--input-placeholder-color`  | `#999`                 | `#ccc`         |                                                                                                               |
-| `--num-columns`              | `8`                    |                | How many columns to display in the emoji grid                                                                 |
-| `--outline-color`            | `#999`                 | `#fff`         | Focus outline color                                                                                           |
-| `--outline-size`             | `2px`                  |                | Focus outline width                                                                                           |
-| `--skintone-border-radius`   | `1rem`                 |                | border radius of the skintone dropdown                                                                        |
+| Variable                     | Default                | Default (dark) | Description                                                                                          |
+| ---------------------------- | ---------------------- | -------------- | ---------------------------------------------------------------------------------------------------- |
+| `--background`               | `#fff`                 | `#222`         | Background of the entire `<emoji-picker>`                                                            |
+| `--border-color`             | `#e0e0e0`              | `#444`         |                                                                                                      |
+| `--border-size`              | `1px`                  |                | Width of border used in most of the picker                                                           |
+| `--button-active-background` | `#e6e6e6`              | `#555555`      | Background of an active button                                                                       |
+| `--button-hover-background`  | `#d9d9d9`              | `#484848`      | Background of a hovered button                                                                       |
+| `--category-emoji-padding`   | `var(--emoji-padding)` |                | Vertical/horizontal padding on category emoji, if you want it to be different from `--emoji-padding` |
+| `--category-emoji-size`      | `var(--emoji-size)`    |                | Width/height of category emoji, if you want it to be different from `--emoji-size`                   |
+| `--category-font-color`      | `#111`                 | `#efefef`      | Font color of custom emoji category headings                                                         |
+| `--category-font-size`       | `1rem`                 |                | Font size of custom emoji category headings                                                          |
+| `--emoji-padding`            | `0.5rem`               |                | Vertical and horizontal padding on emoji                                                             |
+| `--emoji-size`               | `1.375rem`             |                | Width and height of all emoji                                                                        |
+| `--indicator-color`          | `#385ac1`              | `#5373ec`      | Color of the nav indicator                                                                           |
+| `--indicator-height`         | `3px`                  |                | Height of the nav indicator                                                                          |
+| `--input-border-color`       | `#999`                 | `#ccc`         |                                                                                                      |
+| `--input-border-radius`      | `0.5rem`               |                |                                                                                                      |
+| `--input-border-size`        | `1px`                  |                |                                                                                                      |
+| `--input-font-color`         | `#111`                 | `#efefef`      |                                                                                                      |
+| `--input-font-size`          | `1rem`                 |                |                                                                                                      |
+| `--input-line-height`        | `1.5`                  |                |                                                                                                      |
+| `--input-padding`            | `0.25rem`              |                |                                                                                                      |
+| `--input-placeholder-color`  | `#999`                 | `#ccc`         |                                                                                                      |
+| `--num-columns`              | `8`                    |                | How many columns to display in the emoji grid                                                        |
+| `--outline-color`            | `#999`                 | `#fff`         | Focus outline color                                                                                  |
+| `--outline-size`             | `2px`                  |                | Focus outline width                                                                                  |
+| `--skintone-border-radius`   | `1rem`                 |                | border radius of the skintone dropdown                                                               |
 
 <!-- CSS variable options end -->
 

--- a/README.md
+++ b/README.md
@@ -179,31 +179,33 @@ Here is a full list of options:
 
 <!-- CSS variable options start -->
 
-| Variable                     | Default    | Default (dark) | Description                                   |
-| ---------------------------- | ---------- | -------------- | --------------------------------------------- |
-| `--background`               | `#fff`     | `#222`         | Background of the entire `<emoji-picker>`     |
-| `--border-color`             | `#e0e0e0`  | `#444`         |                                               |
-| `--border-size`              | `1px`      |                | Width of border used in most of the picker    |
-| `--button-active-background` | `#e6e6e6`  | `#555555`      | Background of an active button                |
-| `--button-hover-background`  | `#d9d9d9`  | `#484848`      | Background of a hovered button                |
-| `--category-font-color`      | `#111`     | `#efefef`      | Font color of custom emoji category headings  |
-| `--category-font-size`       | `1rem`     |                | Font size of custom emoji category headings   |
-| `--emoji-padding`            | `0.5rem`   |                |                                               |
-| `--emoji-size`               | `1.375rem` |                |                                               |
-| `--indicator-color`          | `#385ac1`  | `#5373ec`      | Color of the nav indicator                    |
-| `--indicator-height`         | `3px`      |                | Height of the nav indicator                   |
-| `--input-border-color`       | `#999`     | `#ccc`         |                                               |
-| `--input-border-radius`      | `0.5rem`   |                |                                               |
-| `--input-border-size`        | `1px`      |                |                                               |
-| `--input-font-color`         | `#111`     | `#efefef`      |                                               |
-| `--input-font-size`          | `1rem`     |                |                                               |
-| `--input-line-height`        | `1.5`      |                |                                               |
-| `--input-padding`            | `0.25rem`  |                |                                               |
-| `--input-placeholder-color`  | `#999`     | `#ccc`         |                                               |
-| `--num-columns`              | `8`        |                | How many columns to display in the emoji grid |
-| `--outline-color`            | `#999`     | `#fff`         | Focus outline color                           |
-| `--outline-size`             | `2px`      |                | Focus outline width                           |
-| `--skintone-border-radius`   | `1rem`     |                | border radius of the skintone dropdown        |
+| Variable                     | Default                | Default (dark) | Description                                                                                                   |
+| ---------------------------- | ---------------------- | -------------- | ------------------------------------------------------------------------------------------------------------- |
+| `--background`               | `#fff`                 | `#222`         | Background of the entire `<emoji-picker>`                                                                     |
+| `--border-color`             | `#e0e0e0`              | `#444`         |                                                                                                               |
+| `--border-size`              | `1px`                  |                | Width of border used in most of the picker                                                                    |
+| `--button-active-background` | `#e6e6e6`              | `#555555`      | Background of an active button                                                                                |
+| `--button-hover-background`  | `#d9d9d9`              | `#484848`      | Background of a hovered button                                                                                |
+| `--category-emoji-padding`   | `var(--emoji-padding)` |                | Vertical/horizontal padding on category emoji, if you want it to be different from `--category-emoji-padding` |
+| `--category-emoji-size`      | `var(--emoji-size)`    |                | Width/height of category emoji, if you want it to be different from `--emoji-size`                            |
+| `--category-font-color`      | `#111`                 | `#efefef`      | Font color of custom emoji category headings                                                                  |
+| `--category-font-size`       | `1rem`                 |                | Font size of custom emoji category headings                                                                   |
+| `--emoji-padding`            | `0.5rem`               |                | Vertical and horizontal padding on emoji                                                                      |
+| `--emoji-size`               | `1.375rem`             |                | Width and height of all emoji                                                                                 |
+| `--indicator-color`          | `#385ac1`              | `#5373ec`      | Color of the nav indicator                                                                                    |
+| `--indicator-height`         | `3px`                  |                | Height of the nav indicator                                                                                   |
+| `--input-border-color`       | `#999`                 | `#ccc`         |                                                                                                               |
+| `--input-border-radius`      | `0.5rem`               |                |                                                                                                               |
+| `--input-border-size`        | `1px`                  |                |                                                                                                               |
+| `--input-font-color`         | `#111`                 | `#efefef`      |                                                                                                               |
+| `--input-font-size`          | `1rem`                 |                |                                                                                                               |
+| `--input-line-height`        | `1.5`                  |                |                                                                                                               |
+| `--input-padding`            | `0.25rem`              |                |                                                                                                               |
+| `--input-placeholder-color`  | `#999`                 | `#ccc`         |                                                                                                               |
+| `--num-columns`              | `8`                    |                | How many columns to display in the emoji grid                                                                 |
+| `--outline-color`            | `#999`                 | `#fff`         | Focus outline color                                                                                           |
+| `--outline-size`             | `2px`                  |                | Focus outline width                                                                                           |
+| `--skintone-border-radius`   | `1rem`                 |                | border radius of the skintone dropdown                                                                        |
 
 <!-- CSS variable options end -->
 

--- a/package.json
+++ b/package.json
@@ -188,12 +188,12 @@
   "bundlesize": [
     {
       "path": "./bundle.js",
-      "maxSize": "41.1 kB",
+      "maxSize": "41.2 kB",
       "compression": "none"
     },
     {
       "path": "./bundle.js",
-      "maxSize": "15 kB",
+      "maxSize": "13 kB",
       "compression": "brotli"
     }
   ]

--- a/src/picker/components/Picker/Picker.html
+++ b/src/picker/components/Picker/Picker.html
@@ -89,7 +89,7 @@
               aria-selected={!searchMode && currentGroup.id === group.id}
               title={i18n.categories[group.name]}
               on:click={() => onNavClick(group)}>
-        <div class="emoji">
+        <div class="nav-emoji emoji">
           {group.emoji}
         </div>
       </button>

--- a/src/picker/components/Picker/Picker.scss
+++ b/src/picker/components/Picker/Picker.scss
@@ -133,7 +133,7 @@ button.emoji,
   align-items: center;
 }
 
-.nav-button .emoji {
+.nav-emoji {
   font-size: var(--category-emoji-size);
   width: var(--total-category-emoji-size);
   height: var(--total-category-emoji-size);

--- a/src/picker/components/Picker/Picker.scss
+++ b/src/picker/components/Picker/Picker.scss
@@ -133,6 +133,12 @@ button.emoji,
   align-items: center;
 }
 
+.nav-button .emoji {
+  font-size: var(--category-emoji-size);
+  width: var(--total-category-emoji-size);
+  height: var(--total-category-emoji-size);
+}
+
 //
 // indicator
 //

--- a/src/picker/styles/global.scss
+++ b/src/picker/styles/global.scss
@@ -18,6 +18,7 @@
 
   // private variables
   --total-emoji-size: calc(var(--emoji-size) + (2 * var(--emoji-padding)));
+  --total-category-emoji-size: calc(var(--category-emoji-size) + (2 * var(--category-emoji-padding)));
 }
 
 // via https://stackoverflow.com/a/19758620

--- a/src/picker/styles/variables.scss
+++ b/src/picker/styles/variables.scss
@@ -1,6 +1,8 @@
 @mixin sizes() {
-  --emoji-padding: 0.5rem;
-  --emoji-size: 1.375rem;
+  --emoji-size: 1.375rem; /* Width and height of all emoji */
+  --emoji-padding: 0.5rem; /* Vertical and horizontal padding on emoji */
+  --category-emoji-size: var(--emoji-size); /* Width/height of category emoji, if you want it to be different from `--emoji-size` */
+  --category-emoji-padding: var(--emoji-padding); /* Vertical/horizontal padding on category emoji, if you want it to be different from `--category-emoji-padding` */
   --indicator-height: 3px; /* Height of the nav indicator */
   --input-border-radius: 0.5rem;
   --input-border-size: 1px;

--- a/src/picker/styles/variables.scss
+++ b/src/picker/styles/variables.scss
@@ -2,7 +2,7 @@
   --emoji-size: 1.375rem; /* Width and height of all emoji */
   --emoji-padding: 0.5rem; /* Vertical and horizontal padding on emoji */
   --category-emoji-size: var(--emoji-size); /* Width/height of category emoji, if you want it to be different from `--emoji-size` */
-  --category-emoji-padding: var(--emoji-padding); /* Vertical/horizontal padding on category emoji, if you want it to be different from `--category-emoji-padding` */
+  --category-emoji-padding: var(--emoji-padding); /* Vertical/horizontal padding on category emoji, if you want it to be different from `--emoji-padding` */
   --indicator-height: 3px; /* Height of the nav indicator */
   --input-border-radius: 0.5rem;
   --input-border-size: 1px;

--- a/src/picker/styles/variables.scss
+++ b/src/picker/styles/variables.scss
@@ -12,7 +12,7 @@
   --num-columns: 8; /* How many columns to display in the emoji grid */
   --outline-size: 2px; /* Focus outline width */
   --border-size: 1px; /* Width of border used in most of the picker */
-  --skintone-border-radius: 1rem; /* border radius of the skintone dropdown */
+  --skintone-border-radius: 1rem; /* Border radius of the skintone dropdown */
   --category-font-size: 1rem; /* Font size of custom emoji category headings */
 }
 


### PR DESCRIPTION
fixes #133

Adds two new CSS variables: `--category-emoji-padding` and `--category-emoji-size`. Both default to `--emoji-padding` and `--emoji-size`.