### PR TITLE
fix: remove unused code

### DIFF
--- a/src/database/Database.js
+++ b/src/database/Database.js
@@ -129,7 +129,6 @@ export default class Database {
     try {
       await this._lazyUpdate // allow any lazy updates to process before closing/deleting
     } catch (err) { /* ignore network errors (offline-first) */ }
-    return !!this._db // return true if we need to actually run the close/delete logic
   }
 
   // clear references to IDB, e.g. during a close event
@@ -143,18 +142,12 @@ export default class Database {
   }
 
   async close () {
-    // TODO: this else never gets hit in tests
-    /* istanbul ignore else */
-    if (await this._shutdown()) {
-      await closeDatabase(this._dbName)
-    }
+    await this._shutdown()
+    await closeDatabase(this._dbName)
   }
 
   async delete () {
-    // TODO: this else never gets hit in tests
-    /* istanbul ignore else */
-    if (await this._shutdown()) {
-      await deleteDatabase(this._dbName)
-    }
+    await this._shutdown()
+    await deleteDatabase(this._dbName)
   }
 }


### PR DESCRIPTION
Jest 27 was complaining about this code path never getting hit. From looking at the code, it seems indeed impossible for the `else` to ever get hit - the `ready()` function always ensures that `this._db` is set, and we `await` it. So it will definitely always return true.

Also this should only really matter if someone calls `db.close()` twice or `db.delete()` twice... which the tests already cover.