### PR TITLE
test: add tests for various constructor options

### DIFF
--- a/test/spec/picker/constructor.test.js
+++ b/test/spec/picker/constructor.test.js
@@ -1,0 +1,42 @@
+import { basicAfterEach, basicBeforeEach, mockDefaultDataSource, tick } from '../shared'
+import Picker from '../../../src/picker/PickerElement'
+import { getByRole, waitFor } from '@testing-library/dom'
+import { DEFAULT_DATA_SOURCE, DEFAULT_LOCALE } from '../../../src/database/constants'
+
+describe('constructor', () => {
+  beforeEach(basicBeforeEach)
+  afterEach(basicAfterEach)
+
+  async function testWithDefaults (...args) {
+    mockDefaultDataSource()
+    const picker = new Picker(...args)
+    document.body.appendChild(picker)
+    const container = picker.shadowRoot.querySelector('.picker')
+    await tick(20)
+
+    await waitFor(() => expect(getByRole(container, 'menuitem', { name: /😀/ })).toBeVisible())
+    expect(getByRole(container, 'menuitem', { name: /😀/ })).toBeVisible()
+
+    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(fetch).toHaveBeenLastCalledWith(DEFAULT_DATA_SOURCE, undefined)
+
+    document.body.removeChild(picker)
+    await tick(20)
+  }
+
+  test('contructor with undefined options works', async () => {
+    await testWithDefaults()
+  })
+
+  test('contructor with empty options object works', async () => {
+    await testWithDefaults({})
+  })
+
+  test('contructor with just dataSource option works', async () => {
+    await testWithDefaults({ dataSource: DEFAULT_DATA_SOURCE })
+  })
+
+  test('contructor with just locale option works', async () => {
+    await testWithDefaults({ locale: DEFAULT_LOCALE })
+  })
+})

--- a/test/spec/picker/dataSource.test.js
+++ b/test/spec/picker/dataSource.test.js
@@ -1,4 +1,6 @@
 import {
+  basicAfterEach,
+  basicBeforeEach,
   EMOJIBASE_V5, mockDataSourceWithArraySkinTones,
   mockDataSourceWithNoShortcodes,
   mockEmojibaseV5DataSource,
@@ -11,6 +13,9 @@ import { fireEvent, getByRole, waitFor } from '@testing-library/dom'
 import { openSkintoneListbox } from './shared'
 
 describe('dataSource test', () => {
+  beforeEach(basicBeforeEach)
+  afterEach(basicAfterEach)
+
   test('emoji with no shortcodes still work', async () => {
     mockDataSourceWithNoShortcodes()
     const dataSource = NO_SHORTCODES

--- a/test/spec/shared.js
+++ b/test/spec/shared.js
@@ -1,6 +1,7 @@
 import allEmoji from 'emoji-picker-element-data/en/emojibase/data.json'
 import frEmoji from 'emoji-picker-element-data/fr/cldr/data.json'
 import allEmojibaseV5Emoji from 'emojibase-data/en/data.json'
+import { DEFAULT_DATA_SOURCE } from '../../src/database/constants'
 
 export function truncateEmoji (allEmoji) {
   // just take the first few emoji from each category, or else it takes forever to insert
@@ -56,6 +57,11 @@ export async function tick (times = 1) {
   for (let i = 0; i < times; i++) {
     await new Promise(resolve => setTimeout(resolve))
   }
+}
+
+export function mockDefaultDataSource () {
+  fetch.get(DEFAULT_DATA_SOURCE, () => new Response(JSON.stringify(truncatedEmoji), { headers: { ETag: 'W/def' } }))
+  fetch.head(DEFAULT_DATA_SOURCE, () => new Response(null, { headers: { ETag: 'W/def' } }))
 }
 
 export function mockFrenchDataSource () {


### PR DESCRIPTION
Adds a test for some Picker constructor options that I almost broke when trying to update Svelte.