### PR TITLE
fix: fix rollup compiler warning

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -54,7 +54,6 @@ const baseConfig = {
     }),
     svelte({
       compilerOptions: {
-        css: true,
         customElement: true,
         dev
       },


### PR DESCRIPTION
Fixes a warning about how this option was forced to false.