### PR TITLE
perf: determine emoji support in reverse order

### DIFF
--- a/bin/versionsAndTestEmoji.js
+++ b/bin/versionsAndTestEmoji.js
@@ -10,7 +10,7 @@
 export const versionsAndTestEmoji = {
   '🥲': 13.1, // smiling face with tear, technically from v13 but see note above
   '🥻': 12.1, // sari, technically from v12 but see note above
-  '🥰': 11, // smiling face with hearts
+  '🥰': 11,
   '🤩': 5,
   '👱‍♀️': 4,
   '🤣': 3,

--- a/bin/versionsAndTestEmoji.js
+++ b/bin/versionsAndTestEmoji.js
@@ -8,7 +8,7 @@
 // "face without mouth" plus "fog".) These emoji can only be filtered using the width test,
 // which happens in checkZwjSupport.js.
 export const versionsAndTestEmoji = {
-  '🥲': 13.1, // smiling face with tear, technically from v13 but see note above,
+  '🥲': 13.1, // smiling face with tear, technically from v13 but see note above
   '🥻': 12.1, // sari, technically from v12 but see note above
   '🥰': 11, // smiling face with hearts
   '🤩': 5,

--- a/bin/versionsAndTestEmoji.js
+++ b/bin/versionsAndTestEmoji.js
@@ -8,14 +8,14 @@
 // "face without mouth" plus "fog".) These emoji can only be filtered using the width test,
 // which happens in checkZwjSupport.js.
 export const versionsAndTestEmoji = {
-  '😃': 0.6,
-  '😐️': 0.7,
-  '😀': 1,
-  '👁️‍🗨️': 2,
-  '🤣': 3,
-  '👱‍♀️': 4,
-  '🤩': 5,
-  '🥰': 11, // smiling face with hearts
+  '🥲': 13.1, // smiling face with tear, technically from v13 but see note above,
   '🥻': 12.1, // sari, technically from v12 but see note above
-  '🥲': 13.1 // smiling face with tear, technically from v13 but see note above
+  '🥰': 11, // smiling face with hearts
+  '🤩': 5,
+  '👱‍♀️': 4,
+  '🤣': 3,
+  '👁️‍🗨️': 2,
+  '😀': 1,
+  '😐️': 0.7,
+  '😃': 0.6
 }

--- a/src/picker/utils/determineEmojiSupportLevel.js
+++ b/src/picker/utils/determineEmojiSupportLevel.js
@@ -6,9 +6,10 @@ import { testColorEmojiSupported } from './testColorEmojiSupported'
 /* istanbul ignore next */
 export function determineEmojiSupportLevel () {
   performance.mark('determineEmojiSupportLevel')
+  const entries = Object.entries(versionsAndTestEmoji)
   try {
     // start with latest emoji and work backwards
-    for (const [emoji, version] of Object.entries(versionsAndTestEmoji)) {
+    for (const [emoji, version] of entries) {
       if (testColorEmojiSupported(emoji)) {
         return version
       }
@@ -20,5 +21,5 @@ export function determineEmojiSupportLevel () {
   }
   // In case of an error, be generous and just assume all emoji are supported (e.g. for canvas errors
   // due to anti-fingerprinting add-ons). Better to show some gray boxes than nothing at all.
-  return Object.values(versionsAndTestEmoji)[0] // assume the first one is largest
+  return entries[0][1] // first one in the list is the most recent version
 }

--- a/src/picker/utils/determineEmojiSupportLevel.js
+++ b/src/picker/utils/determineEmojiSupportLevel.js
@@ -7,17 +7,18 @@ import { testColorEmojiSupported } from './testColorEmojiSupported'
 export function determineEmojiSupportLevel () {
   performance.mark('determineEmojiSupportLevel')
   try {
-    let res
+    // start with latest emoji and work backwards
     for (const [emoji, version] of Object.entries(versionsAndTestEmoji)) {
       if (testColorEmojiSupported(emoji)) {
-        res = version
+        return version
       }
     }
-    return res
   } catch (e) { // canvas error
     console.log('Ignoring canvas error', e)
-    return Math.max(...Object.values(versionsAndTestEmoji))
   } finally {
     performance.measure('determineEmojiSupportLevel', 'determineEmojiSupportLevel')
   }
+  // In case of an error, be generous and just assume all emoji are supported (e.g. for canvas errors
+  // due to anti-fingerprinting add-ons). Better to show some gray boxes than nothing at all.
+  return Object.values(versionsAndTestEmoji)[0] // assume the first one is largest
 }


### PR DESCRIPTION
Theoretically it should be faster when testing emoji support to start with the latest (13.1) and work backwards, rather than starting with the oldest and working forward, because we can short-circuit if the latest (13.1) is supported, which should be the case in most modern browsers.