### PR TITLE
perf: use relaxed IDB transactions and manually commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
   "bundlesize": [
     {
       "path": "./bundle.js",
-      "maxSize": "41.3 kB",
+      "maxSize": "41.4 kB",
       "compression": "none"
     },
     {

--- a/src/database/databaseLifecycle.js
+++ b/src/database/databaseLifecycle.js
@@ -50,18 +50,18 @@ export function openDatabase (dbName) {
 
 export function dbPromise (db, storeName, readOnlyOrReadWrite, cb) {
   return new Promise((resolve, reject) => {
-    const tx = db.transaction(storeName, readOnlyOrReadWrite)
+    const txn = db.transaction(storeName, readOnlyOrReadWrite, { durability: 'relaxed' })
     const store = typeof storeName === 'string'
-      ? tx.objectStore(storeName)
-      : storeName.map(name => tx.objectStore(name))
+      ? txn.objectStore(storeName)
+      : storeName.map(name => txn.objectStore(name))
     let res
-    cb(store, (result) => {
+    cb(store, txn, (result) => {
       res = result
     })
 
-    tx.oncomplete = () => resolve(res)
+    txn.oncomplete = () => resolve(res)
     /* istanbul ignore next */
-    tx.onerror = () => reject(tx.error)
+    txn.onerror = () => reject(txn.error)
   })
 }
 

--- a/src/database/idbInterface.js
+++ b/src/database/idbInterface.js
@@ -38,7 +38,7 @@ async function doFullDatabaseScanForSingleResult (db, predicate) {
   //   console.log(performance.getEntriesByName('total').slice(-1)[0].duration)
   // })()
   const BATCH_SIZE = 50 // Typically around 150ms for 6x slowdown in Chrome for above benchmark
-  return dbPromise(db, STORE_EMOJI, MODE_READONLY, (emojiStore, cb) => {
+  return dbPromise(db, STORE_EMOJI, MODE_READONLY, (emojiStore, txn, cb) => {
     let lastKey
 
     const processNextBatch = () => {
@@ -64,7 +64,7 @@ export async function loadData (db, emojiData, url, eTag) {
   performance.mark('loadData')
   try {
     const transformedData = transformEmojiData(emojiData)
-    await dbPromise(db, [STORE_EMOJI, STORE_KEYVALUE], MODE_READWRITE, ([emojiStore, metaStore]) => {
+    await dbPromise(db, [STORE_EMOJI, STORE_KEYVALUE], MODE_READWRITE, ([emojiStore, metaStore], txn) => {
       let oldETag
       let oldUrl
       let oldKeys
@@ -91,6 +91,9 @@ export async function loadData (db, emojiData, url, eTag) {
         }
         metaStore.put(eTag, KEY_ETAG)
         metaStore.put(url, KEY_URL)
+        if (txn.commit) {
+          txn.commit()
+        }
         performance.mark('commitAllData')
       }
 
@@ -116,7 +119,7 @@ export async function loadData (db, emojiData, url, eTag) {
 }
 
 export async function getEmojiByGroup (db, group) {
-  return dbPromise(db, STORE_EMOJI, MODE_READONLY, (emojiStore, cb) => {
+  return dbPromise(db, STORE_EMOJI, MODE_READONLY, (emojiStore, txn, cb) => {
     const range = IDBKeyRange.bound([group, 0], [group + 1, 0], false, true)
     getAllIDB(emojiStore.index(INDEX_GROUP_AND_ORDER), range, cb)
   })
@@ -129,7 +132,7 @@ export async function getEmojiBySearchQuery (db, query) {
     return []
   }
 
-  return dbPromise(db, STORE_EMOJI, MODE_READONLY, (emojiStore, cb) => {
+  return dbPromise(db, STORE_EMOJI, MODE_READONLY, (emojiStore, txn, cb) => {
     // get all results that contain all tokens (i.e. an AND query)
     const intermediateResults = []
 
@@ -179,7 +182,7 @@ export async function getEmojiByShortcode (db, shortcode) {
 }
 
 export async function getEmojiByUnicode (db, unicode) {
-  return dbPromise(db, STORE_EMOJI, MODE_READONLY, (emojiStore, cb) => (
+  return dbPromise(db, STORE_EMOJI, MODE_READONLY, (emojiStore, txn, cb) => (
     getIDB(emojiStore, unicode, result => {
       if (result) {
         return cb(result)
@@ -190,7 +193,7 @@ export async function getEmojiByUnicode (db, unicode) {
 }
 
 export function get (db, storeName, key) {
-  return dbPromise(db, storeName, MODE_READONLY, (store, cb) => (
+  return dbPromise(db, storeName, MODE_READONLY, (store, txn, cb) => (
     getIDB(store, key, cb)
   ))
 }
@@ -202,10 +205,13 @@ export function set (db, storeName, key, value) {
 }
 
 export function incrementFavoriteEmojiCount (db, unicode) {
-  return dbPromise(db, STORE_FAVORITES, MODE_READWRITE, (store) => {
-    getIDB(store, unicode, result => (
+  return dbPromise(db, STORE_FAVORITES, MODE_READWRITE, (store, txn) => {
+    getIDB(store, unicode, result => {
       store.put((result || 0) + 1, unicode)
-    ))
+      if (txn.commit) {
+        txn.commit()
+      }
+    })
   })
 }
 
@@ -213,7 +219,7 @@ export function getTopFavoriteEmoji (db, customEmojiIndex, limit) {
   if (limit === 0) {
     return []
   }
-  return dbPromise(db, [STORE_FAVORITES, STORE_EMOJI], MODE_READONLY, ([favoritesStore, emojiStore], cb) => {
+  return dbPromise(db, [STORE_FAVORITES, STORE_EMOJI], MODE_READONLY, ([favoritesStore, emojiStore], txn, cb) => {
     const results = []
     favoritesStore.index(INDEX_COUNT).openCursor(undefined, 'prev').onsuccess = e => {
       const cursor = e.target.result

--- a/src/database/idbInterface.js
+++ b/src/database/idbInterface.js
@@ -91,6 +91,7 @@ export async function loadData (db, emojiData, url, eTag) {
         }
         metaStore.put(eTag, KEY_ETAG)
         metaStore.put(url, KEY_URL)
+        /* istanbul ignore else */
         if (txn.commit) {
           txn.commit()
         }
@@ -208,6 +209,7 @@ export function incrementFavoriteEmojiCount (db, unicode) {
   return dbPromise(db, STORE_FAVORITES, MODE_READWRITE, (store, txn) => {
     getIDB(store, unicode, result => {
       store.put((result || 0) + 1, unicode)
+      /* istanbul ignore else */
       if (txn.commit) {
         txn.commit()
       }


### PR DESCRIPTION
Neither the emoji data nor the favorites data is really so irreplaceable that we can't use relaxed durability transactions. But I'm curious to see if it will actually make a perf difference in the benchmarks.