### PR TITLE
fix: use our own custom element implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,4 @@ dist
 /bundle.js
 /test/benchmark/node_modules
 /test/benchmark/data.json
+/picker.css

--- a/bin/buildStyles.js
+++ b/bin/buildStyles.js
@@ -1,0 +1,19 @@
+import sass from 'sass'
+import cssnano from 'cssnano'
+import path from 'path'
+import postcss from 'postcss'
+import { writeFile } from './fs.js'
+
+const __dirname = path.dirname(new URL(import.meta.url).pathname)
+
+async function main () {
+  const file = path.join(__dirname, '../src/picker/styles/picker.scss')
+  const css = sass.renderSync({ file, outputStyle: 'compressed' }).css
+  const compressedCss = (await postcss([cssnano()]).process(css, { from: undefined })).css
+  await writeFile(path.join(__dirname, '../picker.css'), compressedCss, 'utf8')
+}
+
+main().catch(err => {
+  console.error(err)
+  process.exit(1)
+})

--- a/config/jest.setup.js
+++ b/config/jest.setup.js
@@ -4,6 +4,8 @@ import FDBKeyRange from 'fake-indexeddb/build/FDBKeyRange'
 import { Crypto } from '@peculiar/webcrypto'
 import { ResizeObserver } from 'd2l-resize-aware/resize-observer-module.js'
 import { deleteDatabase } from '../src/database/databaseLifecycle'
+import path from 'path'
+import fs from 'fs'
 
 if (!global.performance) {
   global.performance = {}
@@ -24,6 +26,7 @@ global.crypto = new Crypto()
 global.ResizeObserver = ResizeObserver
 
 process.env.NODE_ENV = 'test'
+process.env.STYLES = fs.readFileSync(path.join(__dirname, '../picker.css'), 'utf8')
 
 global.IDBKeyRange = FDBKeyRange
 global.indexedDB = new FDBFactory()

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -8,8 +8,6 @@ module.exports = {
     '^.+\\.svelte$': ['svelte-jester', {
       preprocess: true,
       compilerOptions: {
-        css: true,
-        customElement: true,
         dev: false
       }
     }]

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   ],
   "scripts": {
     "prepare": "run-s build",
-    "build": "run-s build:rollup build:css-docs build:i18n-docs build:types build:typedoc build:toc",
+    "build": "run-s build:styles build:rollup build:css-docs build:i18n-docs build:types build:typedoc build:toc",
+    "build:styles": "node ./bin/buildStyles",
     "build:rollup": "cross-env NODE_ENV=production rollup -c",
     "build:css-docs": "node ./bin/generateCssDocs",
     "build:i18n-docs": "node ./bin/generateI18nDocs",
@@ -37,7 +38,8 @@
     "test:leak": "run-p --race test:leak:server test:leak:test",
     "test:leak:server": "node ./test/leak/server.js",
     "test:leak:test": "node ./test/leak/test.js",
-    "dev": "run-p --race dev:rollup dev:server",
+    "dev": "run-s build:styles dev:watch",
+    "dev:watch": "run-p --race dev:rollup dev:server",
     "dev:rollup": "cross-env NODE_ENV=development rollup -c -w",
     "dev:server": "node ./test/adhoc/server.js",
     "lint": "standard && stylelint '**/*.scss'",
@@ -105,7 +107,7 @@
     "node-fetch": "^2.6.1",
     "npm-run-all": "^4.1.5",
     "playwright": "^1.12.3",
-    "postcss": "^8.2.1",
+    "postcss": "^8.3.5",
     "pretty-bytes": "^5.4.1",
     "puppeteer": "^10.0.0",
     "recursive-readdir": "^2.2.2",
@@ -155,6 +157,7 @@
       "indexedDB",
       "IDBKeyRange",
       "Headers",
+      "HTMLElement",
       "matchMedia",
       "performance",
       "ResizeObserver",
@@ -196,7 +199,7 @@
   "bundlesize": [
     {
       "path": "./bundle.js",
-      "maxSize": "41.3 kB",
+      "maxSize": "41 kB",
       "compression": "none"
     },
     {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,21 +5,14 @@ import strip from '@rollup/plugin-strip'
 import svelte from 'rollup-plugin-svelte'
 import preprocess from 'svelte-preprocess'
 import analyze from 'rollup-plugin-analyzer'
-import cssnano from 'cssnano'
+import path from 'path'
+import fs from 'fs'
 
+const styles = fs.readFileSync(path.join(__dirname, './picker.css'), 'utf8')
 const { NODE_ENV, DEBUG } = process.env
 const dev = NODE_ENV !== 'production'
 
-const preprocessConfig = preprocess({
-  scss: true,
-  postcss: {
-    plugins: [
-      cssnano({
-        preset: 'default'
-      })
-    ]
-  }
-})
+const preprocessConfig = preprocess()
 
 const origMarkup = preprocessConfig.markup
 // minify the HTML by removing extra whitespace
@@ -45,6 +38,7 @@ const baseConfig = {
     replace({
       'process.env.NODE_ENV': dev ? '"development"' : '"production"',
       'process.env.PERF': !!process.env.PERF,
+      'process.env.STYLES': JSON.stringify(styles),
       preventAssignment: true
     }),
     replace({
@@ -54,17 +48,9 @@ const baseConfig = {
     }),
     svelte({
       compilerOptions: {
-        customElement: true,
         dev
       },
       preprocess: preprocessConfig
-    }),
-    replace({
-      preventAssignment: true,
-      delimiters: ['', ''],
-      // Reduce bundle size by removing this bit
-      // https://github.com/sveltejs/svelte/blob/5d82496/src/runtime/internal/Component.ts#L64-L78
-      '(!customElement)': '(false)'
     }),
     strip({
       include: ['**/*.js', '**/*.svelte'],

--- a/src/picker/components/Picker/Picker.html
+++ b/src/picker/components/Picker/Picker.html
@@ -98,7 +98,7 @@
   <div class="indicator-wrapper">
     <div class="indicator"
          style={indicatorStyle}
-         bind:this={indicatorElement}>
+         use:calculateIndicatorWidth>
     </div>
   </div>
 
@@ -117,7 +117,7 @@
        on:click={onEmojiClick}
        bind:this={tabpanelElement}
   >
-    <div bind:this={tabpanelInnerElement}>
+    <div use:calculateEmojiGridWidth>
       {#each currentEmojisWithCategories as emojiWithCategory, i (emojiWithCategory.category)}
         <div
           id="menu-label-{i}"

--- a/src/picker/components/Picker/Picker.js
+++ b/src/picker/components/Picker/Picker.js
@@ -1,7 +1,6 @@
 /* eslint-disable prefer-const,no-labels,no-inner-declarations */
 
 import Database from '../../ImportedDatabase'
-import enI18n from '../../i18n/en'
 import { groups as defaultGroups, customGroup } from '../../groups'
 import { MIN_SEARCH_TEXT_LENGTH, NUM_SKIN_TONES } from '../../../shared/constants'
 import { requestIdleCallback } from '../../utils/requestIdleCallback'
@@ -12,7 +11,7 @@ import { halt } from '../../utils/halt'
 import { incrementOrDecrement } from '../../utils/incrementOrDecrement'
 import {
   DEFAULT_NUM_COLUMNS,
-  DEFAULT_SKIN_TONE_EMOJI, FONT_FAMILY,
+  FONT_FAMILY,
   MOST_COMMONLY_USED_EMOJI,
   TIMEOUT_BEFORE_LOADING_MESSAGE
 } from '../../constants'
@@ -24,16 +23,15 @@ import { requestPostAnimationFrame } from '../../utils/requestPostAnimationFrame
 import { onMount, tick } from 'svelte'
 import { requestAnimationFrame } from '../../utils/requestAnimationFrame'
 import { uniq } from '../../../shared/uniq'
-import { runAll } from '../../utils/runAll'
 
 // public
-let locale = null
-let dataSource = null
-let skinToneEmoji = DEFAULT_SKIN_TONE_EMOJI
-let i18n = enI18n
-let database = null
-let customEmoji = null
-let customCategorySorting = (a, b) => a < b ? -1 : a > b ? 1 : 0
+let locale
+let dataSource
+let skinToneEmoji
+let i18n
+let database
+let customEmoji
+let customCategorySorting
 
 // private
 let initialLoad = true
@@ -44,8 +42,6 @@ let searchText = ''
 let rootElement
 let baselineEmoji
 let tabpanelElement
-let tabpanelInnerElement
-let indicatorElement
 let searchMode = false // eslint-disable-line no-unused-vars
 let activeSearchItem = -1
 let message // eslint-disable-line no-unused-vars
@@ -144,19 +140,7 @@ $: {
 }
 
 onMount(() => {
-  const destroys = [
-    calculateIndicatorWidth(indicatorElement),
-    // The reason for the tabpanelInnerElement is that, if we measure the width on the tabpanelElement,
-    // then we don't always exclude the scrollbar. In Chrome/WebKit it does, in Firefox it does not.
-    calculateEmojiGridWidth(tabpanelInnerElement)
-  ]
-
   return async () => {
-    // TODO: using a workaround for Svelte actions never calling destroy() when used in
-    // custom elements. Instead of waiting for a destroy event, we use the mount/unmount
-    // lifecycle to clean up.
-    // https://github.com/sveltejs/svelte/issues/5989#issuecomment-796366910
-    runAll(destroys)
     // Close the database when the component is disconnected. It will automatically reconnect anyway
     // if the component is ever reconnected.
     if (database) {

--- a/src/picker/components/Picker/Picker.svelte
+++ b/src/picker/components/Picker/Picker.svelte
@@ -1,3 +1,2 @@
 <template src="./Picker.html"></template>
-<style src="./Picker.scss" lang="scss"></style>
 <script src="./Picker.js"></script>

--- a/src/picker/constants.js
+++ b/src/picker/constants.js
@@ -25,3 +25,6 @@ export const MOST_COMMONLY_USED_EMOJI = [
 
 export const FONT_FAMILY = '"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol",' +
   '"Twemoji Mozilla","Noto Color Emoji","EmojiOne Color","Android Emoji",sans-serif'
+
+/* istanbul ignore next */
+export const DEFAULT_CATEGORY_SORTING = (a, b) => a < b ? -1 : a > b ? 1 : 0

--- a/src/picker/styles/picker.scss
+++ b/src/picker/styles/picker.scss
@@ -1,4 +1,4 @@
-@import '../../styles/global.scss';
+@import 'global';
 
 // These z-indexes are used to manage the skintone picker animation and make it look nicer.
 // The skintone picker should appear to expand "behind" the skintone button.

--- a/src/picker/utils/runAll.js
+++ b/src/picker/utils/runAll.js
@@ -1,1 +1,0 @@
-export const runAll = funcs => (funcs && funcs.forEach(func => func()))

--- a/src/picker/utils/widthCalculator.js
+++ b/src/picker/utils/widthCalculator.js
@@ -24,10 +24,12 @@ export function calculateWidth (node, onUpdate) {
     ))
   }
 
-  // cleanup function (called on disconnect)
-  return () => {
-    if (resizeObserver) {
-      resizeObserver.disconnect()
+  // cleanup function (called on destroy)
+  return {
+    destroy () {
+      if (resizeObserver) {
+        resizeObserver.disconnect()
+      }
     }
   }
 }

--- a/test/benchmark/first-load.tachometer.json
+++ b/test/benchmark/first-load.tachometer.json
@@ -30,8 +30,7 @@
                 "repo": "https://github.com/nolanlawson/emoji-picker-element.git",
                 "ref": "master",
                 "setupCommands": [
-                  "yarn --immutable --ignore-scripts",
-                  "PERF=1 yarn build:rollup"
+                  "PERF=1 yarn --immutable"
                 ]
               }
             }

--- a/test/benchmark/second-load.tachometer.json
+++ b/test/benchmark/second-load.tachometer.json
@@ -30,8 +30,7 @@
                 "repo": "https://github.com/nolanlawson/emoji-picker-element.git",
                 "ref": "master",
                 "setupCommands": [
-                  "yarn --immutable --ignore-scripts",
-                  "PERF=1 yarn build:rollup"
+                  "PERF=1 yarn --immutable"
                 ]
               }
             }

--- a/test/spec/picker/attributes.test.js
+++ b/test/spec/picker/attributes.test.js
@@ -1,6 +1,9 @@
 import { basicAfterEach, basicBeforeEach, FR_EMOJI, ALL_EMOJI, mockFrenchDataSource, tick } from '../shared'
 import Picker from '../../../src/picker/PickerElement.js'
 import { getByRole } from '@testing-library/dom'
+import { DEFAULT_DATA_SOURCE, DEFAULT_LOCALE } from '../../../src/database/constants'
+import enI18n from '../../../src/picker/i18n/en.js'
+import { DEFAULT_CATEGORY_SORTING, DEFAULT_SKIN_TONE_EMOJI } from '../../../src/picker/constants'
 
 describe('attributes tests', () => {
   beforeEach(async () => {
@@ -48,6 +51,113 @@ describe('attributes tests', () => {
     expect(picker.skinToneEmoji).toEqual('🏃')
 
     document.body.removeChild(picker)
+    await tick(20)
+  })
+
+  test('change property while disconnected from DOM', async () => {
+    const picker = new Picker()
+    picker.setAttribute('data-source', ALL_EMOJI)
+    document.body.appendChild(picker)
+    await tick(20)
+    document.body.removeChild(picker)
+    await tick(20)
+    picker.skinToneEmoji = '✌'
+    expect(picker.skinToneEmoji).toEqual('✌')
+    document.body.appendChild(picker)
+    await tick(20)
+
+    expect(getByRole(picker.shadowRoot, 'button', { name: /Choose a skin tone/ }).innerHTML)
+      .toContain('✌')
+    expect(picker.skinToneEmoji).toEqual('✌')
+
+    document.body.removeChild(picker)
+    await tick(20)
+  })
+
+  test('change property while disconnected from DOM', async () => {
+    const picker = new Picker()
+    picker.setAttribute('data-source', ALL_EMOJI)
+    document.body.appendChild(picker)
+    await tick(20)
+    document.body.removeChild(picker)
+    await tick(20)
+    picker.setAttribute('skin-tone-emoji', '✌')
+    expect(picker.skinToneEmoji).toEqual('✌')
+    document.body.appendChild(picker)
+    await tick(20)
+
+    expect(getByRole(picker.shadowRoot, 'button', { name: /Choose a skin tone/ }).innerHTML)
+      .toContain('✌')
+    expect(picker.skinToneEmoji).toEqual('✌')
+    expect(picker.getAttribute('skin-tone-emoji')).toEqual('✌')
+
+    document.body.removeChild(picker)
+    await tick(20)
+  })
+
+  function testDefaultProps (picker) {
+    expect(picker.customCategorySorting).toEqual(DEFAULT_CATEGORY_SORTING)
+    expect(picker.customEmoji).toEqual(null)
+    expect(picker.dataSource).toEqual(DEFAULT_DATA_SOURCE)
+    expect(picker.i18n).toEqual(enI18n)
+    expect(picker.locale).toEqual(DEFAULT_LOCALE)
+    expect(picker.skinToneEmoji).toEqual(DEFAULT_SKIN_TONE_EMOJI)
+  }
+
+  test('default properties - connected', async () => {
+    const picker = new Picker()
+    document.body.appendChild(picker)
+    await tick(20)
+
+    testDefaultProps(picker)
+    expect(typeof picker.database).toEqual('object')
+    expect(picker.database).toBeTruthy()
+
+    document.body.removeChild(picker)
+    await tick(20)
+  })
+
+  test('default properties - disconnected', async () => {
+    const picker = new Picker()
+    document.body.appendChild(picker)
+    await tick(20)
+
+    document.body.removeChild(picker)
+    await tick(20)
+
+    testDefaultProps(picker)
+    expect(picker.database).toEqual(null)
+  })
+
+  test('default properties - never connected', async () => {
+    const picker = new Picker()
+
+    testDefaultProps(picker)
+    expect(picker.database).toEqual(null)
+
+    document.body.appendChild(picker)
+    await tick(20)
+
+    document.body.removeChild(picker)
+    await tick(20)
+  })
+
+  test('attributes present on element at creation time', async () => {
+    const div = document.createElement('div')
+    document.body.appendChild(div)
+    div.innerHTML = `<emoji-picker locale="fr" data-source="${ALL_EMOJI}" skin-tone-emoji="✌"></emoji-picker>`
+    const picker = div.querySelector('emoji-picker')
+    await tick(20)
+    expect(picker.locale).toEqual('fr')
+    expect(picker.dataSource).toEqual(ALL_EMOJI)
+    expect(picker.skinToneEmoji).toEqual('✌')
+    expect(getByRole(picker.shadowRoot, 'button', { name: /Choose a skin tone/ }).innerHTML)
+      .toContain('✌')
+
+    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(fetch).toHaveBeenLastCalledWith(ALL_EMOJI, undefined)
+
+    document.body.removeChild(div)
     await tick(20)
   })
 })

--- a/test/spec/picker/element.test.js
+++ b/test/spec/picker/element.test.js
@@ -30,7 +30,7 @@ describe('element tests', () => {
       basicBeforeEach()
       mockFrenchDataSource()
       picker = new Picker({ dataSource: ALL_EMOJI, locale: 'en' })
-      container = picker.shadowRoot.querySelector('.picker')
+      container = picker.shadowRoot
       document.body.appendChild(picker)
       await tick(20)
     })
@@ -75,8 +75,10 @@ describe('element tests', () => {
       expect(getByRole(container, 'button', { name: /Choose a skin tone/ }).innerHTML)
         .toContain(DEFAULT_SKIN_TONE_EMOJI)
       picker.skinToneEmoji = '👇'
+      await tick(1)
       expect(getByRole(container, 'button', { name: /Choose a skin tone/ }).innerHTML).toContain('👇')
       picker.skinToneEmoji = '👋'
+      await tick(1)
       expect(getByRole(container, 'button', { name: /Choose a skin tone/ }).innerHTML).toContain('👋')
     })
 
@@ -97,7 +99,7 @@ describe('element tests', () => {
     test('has a default locale/dataSource', async () => {
       const picker = new Picker()
       document.body.appendChild(picker)
-      const container = picker.shadowRoot.querySelector('.picker')
+      const container = picker.shadowRoot
       await tick(20)
 
       await waitFor(() => expect(getByRole(container, 'menuitem', { name: /😀/ })).toBeVisible())

--- a/test/spec/picker/errors.test.js
+++ b/test/spec/picker/errors.test.js
@@ -8,14 +8,15 @@ describe('errors', () => {
   afterEach(basicAfterEach)
 
   // seems not possible to do
-  test.skip('throws error when setting the database', async () => {
+  test('throws error when setting the database', async () => {
     const picker = new Picker({ dataSource: ALL_EMOJI, locale: 'en' })
+    document.body.appendChild(picker)
     await tick(20)
     expect(() => {
       picker.database = null
     }).toThrow()
     await tick(20)
-    await new Database({ dataSource: ALL_EMOJI, locale: 'en' }).delete()
+    document.body.removeChild(picker)
     await tick(20)
   })
 
@@ -27,7 +28,7 @@ describe('errors', () => {
     fetch.head(dataSource, { body: null, status: 500 })
 
     const picker = new Picker({ dataSource })
-    const container = picker.shadowRoot.querySelector('.picker')
+    const container = picker.shadowRoot
     document.body.appendChild(picker)
 
     await tick(20)
@@ -50,7 +51,7 @@ describe('errors', () => {
       { delay: 1500 })
 
     const picker = new Picker({ dataSource })
-    const container = picker.shadowRoot.querySelector('.picker')
+    const container = picker.shadowRoot
     document.body.appendChild(picker)
     await tick(20)
 

--- a/test/spec/picker/lifecycle.test.js
+++ b/test/spec/picker/lifecycle.test.js
@@ -10,7 +10,7 @@ describe('lifecycle', () => {
   test('can remove and re-append custom element', async () => {
     mockDefaultDataSource()
     const picker = new Picker()
-    const container = picker.shadowRoot.querySelector('.picker')
+    const container = picker.shadowRoot
 
     document.body.appendChild(picker)
 
@@ -25,9 +25,9 @@ describe('lifecycle', () => {
     document.body.appendChild(picker)
     await waitFor(() => expect(getByRole(container, 'menuitem', { name: /😀/ })).toBeVisible())
 
-    // fetches are unchanged, no new fetches after re-insertion
-    expect(fetch).toHaveBeenCalledTimes(1)
-    expect(fetch).toHaveBeenLastCalledWith(DEFAULT_DATA_SOURCE, undefined)
+    // fetch is called once again after re-insertion
+    expect(fetch).toHaveBeenCalledTimes(2)
+    expect(fetch).toHaveBeenLastCalledWith(DEFAULT_DATA_SOURCE, { method: 'HEAD' })
 
     document.body.removeChild(picker)
     await tick(20)
@@ -37,7 +37,7 @@ describe('lifecycle', () => {
     mockDefaultDataSource()
     const picker = new Picker()
     document.body.appendChild(picker)
-    const container = picker.shadowRoot.querySelector('.picker')
+    const container = picker.shadowRoot
 
     await waitFor(() => expect(getByRole(container, 'menuitem', { name: /😀/ })).toBeVisible())
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7238,7 +7238,7 @@ nan@^2.14.0:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
   integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
 
-nanoid@^3.1.22:
+nanoid@^3.1.23:
   version "3.1.23"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.23.tgz#f744086ce7c2bc47ee0a8472574d5c78e4183a81"
   integrity sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==
@@ -8185,14 +8185,14 @@ postcss@^7.0.14, postcss@^7.0.2, postcss@^7.0.21, postcss@^7.0.26, postcss@^7.0.
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
-postcss@^8.2.1:
-  version "8.2.10"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.2.10.tgz#ca7a042aa8aff494b334d0ff3e9e77079f6f702b"
-  integrity sha512-b/h7CPV7QEdrqIxtAf2j31U5ef05uBDuvoXv6L51Q4rcS1jdlXAVKJv+atCFdUXYl9dyTHGyoMzIepwowRJjFw==
+postcss@^8.3.5:
+  version "8.3.5"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.3.5.tgz#982216b113412bc20a86289e91eb994952a5b709"
+  integrity sha512-NxTuJocUhYGsMiMFHDUkmjSKT3EdH4/WbGF6GCi1NDGk+vbcUTun4fpbOqaPtD8IIsztA2ilZm2DhYCuyN58gA==
   dependencies:
     colorette "^1.2.2"
-    nanoid "^3.1.22"
-    source-map "^0.6.1"
+    nanoid "^3.1.23"
+    source-map-js "^0.6.2"
 
 prebuild-install@^5.3.3:
   version "5.3.4"
@@ -9193,6 +9193,11 @@ slice-ansi@^4.0.0:
     ansi-styles "^4.0.0"
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
+
+source-map-js@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-0.6.2.tgz#0bb5de631b41cfbda6cfba8bd05a80efdfd2385e"
+  integrity sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==
 
 source-map-resolve@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
This is an experiment in using our own implementation of custom elements wrapping a Svelte Component, rather than using Svelte's built-in `customElement` option. It gives us some more flexibility and smaller bundle size at the cost of added complexity, especially with handling styles.