### PR TITLE
fix: fix tabPanel scrollTop bug

### DIFF
--- a/src/picker/components/Picker/Picker.js
+++ b/src/picker/components/Picker/Picker.js
@@ -313,9 +313,11 @@ $: {
     requestAnimationFrame(() => checkZwjSupportAndUpdate(zwjEmojisToCheck))
   } else {
     currentEmojis = currentEmojis.filter(isZwjSupported)
-    requestAnimationFrame(() => { // reset scroll top to 0 when emojis change
-      if (tabpanelElement) { // can be null if element is disconnected immediately after connected
+    requestAnimationFrame(() => { // reset scroll top to 0 when emojis change]
+      try {
         tabpanelElement.scrollTop = 0
+      } catch (e) {
+        // tabpanelElement can be null if element is disconnected immediately after connected. ignore
       }
     })
   }


### PR DESCRIPTION
Fixes a bug that snuck in in 1.6.3 that causes an infinite requestAnimationFrame loop due to Svelte invalidations.