### PR TITLE
fix: use Object.prototype.hasOwnProperty

### DIFF
--- a/src/picker/PickerElement.js
+++ b/src/picker/PickerElement.js
@@ -35,7 +35,7 @@ export default class PickerElement extends HTMLElement {
     }
     // Handle properties set before the element was upgraded
     for (const prop of PROPS) {
-      if (prop !== 'database' && Object.hasOwnProperty.call(this, prop)) {
+      if (prop !== 'database' && Object.prototype.hasOwnProperty.call(this, prop)) {
         this._ctx[prop] = this[prop]
         delete this[prop]
       }


### PR DESCRIPTION
After reading https://eslint.org/docs/rules/no-prototype-builtins, I realized I was doing this slightly wrong. Although it probably doesn't matter, and it's probably safe to use `this.hasOwnProperty`. But I guess to play it safe I'll abide by the rule.