### PR TITLE
docs: add docs for react

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ This will log:
 
 - [Demo](https://nolanlawson.github.io/emoji-picker-element)
 - [Button with tooltip/popover](https://bl.ocks.org/nolanlawson/781e7084e4c17acb921357489d51a5b0)
+- [In a React app](https://codepen.io/nolanlawson/pen/bGWmmrz)
 
 ## Styling
 


### PR DESCRIPTION
Closes #183 

Rather than #187 I'd rather just add some docs demonstrating how to use `emoji-picker-element` in React. Maintaining our own React wrapper is too much work IMO. React should improve their custom element integration.