### PR TITLE
fix: update favorites only on mount

### DIFF
--- a/src/picker/components/Picker/Picker.js
+++ b/src/picker/components/Picker/Picker.js
@@ -496,8 +496,6 @@ async function clickEmoji (unicodeOrName) {
     .find(_ => (_.id === unicodeOrName))
   const skinTonedUnicode = emojiSummary.unicode && unicodeWithSkin(emojiSummary, currentSkinTone)
   await database.incrementFavoriteEmojiCount(unicodeOrName)
-  // eslint-disable-next-line no-self-assign
-  defaultFavoriteEmojis = defaultFavoriteEmojis // force favorites to re-render
   fireEvent('emoji-click', {
     emoji,
     skinTone: currentSkinTone,


### PR DESCRIPTION
Fixes #205

I can't really think of a strong reason to update the favorites immediately. The favorites are an enhancement; they aren't a critical part of the experience. And it's confusing to see them move around.

If people want these to update, they can create a new `<emoji-picker>` element or remove it from the DOM and re-insert it into the DOM. This seems reasonable to me as most pickers I imagine will be created on-demand and dismissed as soon as the user picks an emoji. If not, the favorites will update when the page is refreshed.