### PR TITLE
fix: support RTL direction

### DIFF
--- a/src/picker/components/Picker/Picker.html
+++ b/src/picker/components/Picker/Picker.html
@@ -77,7 +77,7 @@
   </div>
   <div class="nav"
        role="tablist"
-       style="grid-template-columns: repeat({groups.length}, 1fr);"
+       style="grid-template-columns: repeat({groups.length}, 1fr)"
        aria-label={i18n.categoriesLabel}
        on:keydown={onNavKeydown}>
     {#each groups as group (group.id)}
@@ -95,7 +95,8 @@
     {/each}
   </div>
   <div class="indicator-wrapper">
-    <div class="indicator" style={indicatorStyle}>
+    <div class="indicator"
+         style="transform: translateX({(isRtl ? -1 : 1) * currentGroupIndex * 100}%)">
     </div>
   </div>
 
@@ -114,7 +115,7 @@
        on:click={onEmojiClick}
        bind:this={tabpanelElement}
   >
-    <div use:calculateEmojiGridWidth>
+    <div use:calculateEmojiGridStyle>
       {#each currentEmojisWithCategories as emojiWithCategory, i (emojiWithCategory.category)}
         <div
           id="menu-label-{i}"
@@ -161,7 +162,7 @@
   <div class="favorites emoji-menu {message ? 'gone': ''}"
        role="menu"
        aria-label={i18n.favoritesLabel}
-       style="padding-right: {scrollbarWidth}px;"
+       style="padding-inline-end: {scrollbarWidth}px"
        on:click={onEmojiClick}
        data-testid="favorites">
     <!-- The reason the emoji logic below is largely duplicated is because it turns out we get a smaller

--- a/src/picker/styles/picker.scss
+++ b/src/picker/styles/picker.scss
@@ -41,6 +41,12 @@ $skintoneZIndex3: 3;
     transition-duration: 0.001s;
   }
 
+  // TODO: remove this when old iOS Safari drops out of usage: https://caniuse.com/css-logical-props
+  // For now, we don't support RTL in old versions of iOS
+  @supports not (inset-inline-end: 0) {
+    right: 0;
+  }
+
   &.no-animate {
     transition: none;
   }

--- a/src/picker/styles/picker.scss
+++ b/src/picker/styles/picker.scss
@@ -21,7 +21,7 @@ $skintoneZIndex3: 3;
 
 .skintone-list {
   position: absolute;
-  right: 0;
+  inset-inline-end: 0;
   top: 0;
   z-index: $skintoneZIndex2;
   overflow: visible;
@@ -175,12 +175,11 @@ button.emoji,
   background: var(--background);
 }
 
-
 .search-row {
   display: flex;
   align-items: center;
   position: relative;
-  padding-left: var(--emoji-padding);
+  padding-inline-start: var(--emoji-padding);
   padding-bottom: var(--emoji-padding);
 }
 

--- a/test/adhoc/index.html
+++ b/test/adhoc/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" dir="rtl">
 <head>
   <meta charset="UTF-8">
   <title>Ad-hoc emoji-picker-element test</title>
@@ -18,6 +18,8 @@
     @media screen and (max-width: 320px) {
       emoji-picker {
         width: 100%;
+        --num-columns: 6;
+        --category-emoji-size: 1.125rem;
       }
     }
     @media screen and (max-width: 240px) {

--- a/test/adhoc/index.html
+++ b/test/adhoc/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" dir="rtl">
+<html lang="en">
 <head>
   <meta charset="UTF-8">
   <title>Ad-hoc emoji-picker-element test</title>


### PR DESCRIPTION
fixes #212

![Screenshot from 2021-08-13 15-44-12](https://user-images.githubusercontent.com/283842/129425635-23c0729f-ec54-4480-a8d3-ec8302cf1bf1.png)

I'm not sure if I'm ready to merge this yet. I'm using CSS logical properties, which is still not supported in old versions of iOS: https://caniuse.com/css-logical-props

I'm trying to think if there's a good workaround that doesn't involve a lot of gymnastics. Slight differences in padding/margin are fine in my opinion, but for the skintone picker it becomes completely unusable on old iOS in LTR because it appears on the left instead of on the right.