### PR TITLE
fix: respect the hidden attribute

### DIFF
--- a/src/picker/styles/variables.scss
+++ b/src/picker/styles/variables.scss
@@ -78,3 +78,8 @@
     @include colors(true);
   }
 }
+
+// See https://developers.google.com/web/fundamentals/web-components/best-practices
+:host([hidden]) {
+  display: none;
+}


### PR DESCRIPTION
TIL about the `hidden` attribute. Apparently [web components are supposed to respect it](https://developers.google.com/web/fundamentals/web-components/best-practices#set-a-:host-display-style-e.g.-block,-inline-block,-flex-unless-you-prefer-the-default-of-inline.).