### PR TITLE
Detect support for country flags

### DIFF
--- a/src/picker/components/Picker/Picker.js
+++ b/src/picker/components/Picker/Picker.js
@@ -99,7 +99,7 @@ const isSkinToneOption = element => /^skintone-/.test(element.id)
 emojiSupportLevelPromise.then(level => {
   // Can't actually test emoji support in Jest/JSDom, emoji never render in color in Cairo
   /* istanbul ignore next */
-  if (!level) {
+  if (!level?.version) {
     message = i18n.emojiUnsupportedMessage
   }
 })
@@ -323,8 +323,16 @@ function isZwjSupported (emoji) {
 
 async function filterEmojisByVersion (emojis) {
   const emojiSupportLevel = await emojiSupportLevelPromise
+
   // !version corresponds to custom emoji
-  return emojis.filter(({ version }) => !version || version <= emojiSupportLevel)
+  const emojisByVersion = emojis.filter(({ version }) => !version || version <= emojiSupportLevel.version)
+  if (emojiSupportLevel.countryFlags) {
+    return emojisByVersion
+  } else {
+    // a country flag emoji is a sequence two "regional indicator symbols"
+    const countryFlagRegex = /^[\uD83C][\uDDE6-\uDDFF][\uD83C][\uDDE6-\uDDFF]$/
+    return emojisByVersion.filter(({ unicode }) => !countryFlagRegex.test(unicode))
+  }
 }
 
 async function summarizeEmojis (emojis) {

--- a/src/picker/utils/determineEmojiSupportLevel.js
+++ b/src/picker/utils/determineEmojiSupportLevel.js
@@ -7,10 +7,19 @@ export function determineEmojiSupportLevel () {
   performance.mark('determineEmojiSupportLevel')
   const entries = Object.entries(versionsAndTestEmoji)
   try {
+    // Country flags were already included in emoji version 1.0 but still some platforms (eg Chromium on
+    // Windows 10) do not support them natively, rendering a 2-letter country code instead. This breaks
+    // our assumption that if one emoji from a version is supported, all other emojis from that version
+    // are too.therefore, we must treat country flags separately.
+    const countryFlags = testColorEmojiSupported('🇦🇱')
+
     // start with latest emoji and work backwards
     for (const [emoji, version] of entries) {
       if (testColorEmojiSupported(emoji)) {
-        return version
+        return {
+          version,
+          countryFlags
+        }
       }
     }
   } catch (e) { // canvas error
@@ -20,5 +29,8 @@ export function determineEmojiSupportLevel () {
   }
   // In case of an error, be generous and just assume all emoji are supported (e.g. for canvas errors
   // due to anti-fingerprinting add-ons). Better to show some gray boxes than nothing at all.
-  return entries[0][1] // first one in the list is the most recent version
+  return {
+    version: entries[0][1], // first one in the list is the most recent version
+    countryFlags: true
+  }
 }

--- a/src/picker/utils/summarizeEmojisForUI.js
+++ b/src/picker/utils/summarizeEmojisForUI.js
@@ -8,7 +8,7 @@ export function summarizeEmojisForUI (emojis, emojiSupportLevel) {
       // ignore arrays like [1, 2] with multiple skin tones
       // also ignore variants that are in an unsupported emoji version
       // (these do exist - variants from a different version than their base emoji)
-      if (typeof skin.tone === 'number' && skin.version <= emojiSupportLevel) {
+      if (typeof skin.tone === 'number' && skin.version <= emojiSupportLevel.version) {
         res[skin.tone] = skin.unicode
       }
     }

--- a/test/spec/picker/emojiSupport.test.js
+++ b/test/spec/picker/emojiSupport.test.js
@@ -4,7 +4,7 @@ import { setSimulateCanvasError, setSimulateOldBrowser } from '../../../src/pick
 
 describe('emoji support', () => {
   test('returns latest emoji', () => {
-    const version = determineEmojiSupportLevel()
+    const { version } = determineEmojiSupportLevel()
     expect(version).toEqual(Math.max(...Object.values(versionsAndTestEmoji)))
   })
 
@@ -18,7 +18,7 @@ describe('emoji support', () => {
     })
 
     test('returns latest emoji when there is a canvas error', () => {
-      const version = determineEmojiSupportLevel()
+      const { version } = determineEmojiSupportLevel()
       expect(version).toEqual(Math.max(...Object.values(versionsAndTestEmoji)))
     })
   })
@@ -33,7 +33,7 @@ describe('emoji support', () => {
     })
 
     test('returns older emoji version for older browser', () => {
-      const version = determineEmojiSupportLevel()
+      const { version } = determineEmojiSupportLevel()
       expect(version).toEqual(11)
     })
   })


### PR DESCRIPTION
Hi!

Windows 10 does not, as it appears, natively support country flag emojis. I'm not 100% sure whether this holds for all Windows 10 installations and whether it can be fixed, but it holds for mine. Here's a screenshot from my computer (this is Edge on Windows 10)

![image](https://user-images.githubusercontent.com/703546/159004620-9f8de512-e2a6-4f1b-9f94-1792abeb9087.png)

Chrome behaves the same, Firefox does not - it shows nice flags like you'd expect. It looks like they have a special code path for country flags. 

I'm no emoji guru, but to my understanding, country flags are actually part of Emoji 1.0, which means that Windows not supporting them breaks emoji-picker-element's assumption that if one emoji in a version is supported, all the others are too.

This PR is an attempt of mine to address this - it's really just an exploration and I'm happy to solve it in a different direction or simply throw it all away and turn this PR into a bug report. I tried to maintain your spirit of "trying to skate where the puck is going", ie simply not show country flag emojis if the system doesn't support them yet. (That said, [some redditors](https://www.reddit.com/r/Windows11/comments/oj8zep/flag_emojis_coming_to_windows_11_or_not/hdsb03j/?utm_source=reddit&utm_medium=web2x&context=3) suggest that Windows will never support country flags because they want to stay out of hot geopolitical debates, so maybe this puck isn't really going anywhere)

Fortunately, the weird 2-letter country capitals ("AL" etc) are correctly detected by your existing code as "not a color emoji", so this was pretty easy to add - I simply had to add an additional dimension to the concept of the "emoji support level".

I'm not sure how to best add test coverage for this.

With this PR applied, it looks like this: 

![image](https://user-images.githubusercontent.com/703546/159005308-3f5ddc0f-7bd1-498e-9d14-089dcce1b377.png)
