### PR TITLE
fix: newer emoji and flags on Firefox on Windows

### DIFF
--- a/src/picker/constants.js
+++ b/src/picker/constants.js
@@ -23,6 +23,11 @@ export const MOST_COMMONLY_USED_EMOJI = [
   '😘'
 ]
 
+// It's important to list Twemoji Mozilla before everything else, because Mozilla bundles their
+// own font on some platforms (notably Windows and Linux as of this writing). Typically Mozilla
+// updates faster than the underlying OS, and we don't want to render older emoji in one font and
+// newer emoji in another font:
+// https://github.com/nolanlawson/emoji-picker-element/pull/268#issuecomment-1073347283
 export const FONT_FAMILY = '"Twemoji Mozilla","Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol",' +
   '"Noto Color Emoji","EmojiOne Color","Android Emoji",sans-serif'
 

--- a/src/picker/constants.js
+++ b/src/picker/constants.js
@@ -23,8 +23,8 @@ export const MOST_COMMONLY_USED_EMOJI = [
   '😘'
 ]
 
-export const FONT_FAMILY = '"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol",' +
-  '"Twemoji Mozilla","Noto Color Emoji","EmojiOne Color","Android Emoji",sans-serif'
+export const FONT_FAMILY = '"Twemoji Mozilla","Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol",' +
+  '"Noto Color Emoji","EmojiOne Color","Android Emoji",sans-serif'
 
 /* istanbul ignore next */
 export const DEFAULT_CATEGORY_SORTING = (a, b) => a < b ? -1 : a > b ? 1 : 0


### PR DESCRIPTION
Previous discussion: https://github.com/nolanlawson/emoji-picker-element/pull/268#issuecomment-1073347283

On Windows and Linux (but apparently not MacOS or Android), Firefox ships its own `"Twemoji Mozilla"` font. On Windows in particular, the conflicts with the existing Segoe UI font, causing several issues:

- Older emoji render in Segoe, newer emoji render in Twemoji
- Transgender flag renders as double emoji
- England, Scotland, and Wales flags render as black flags

This PR changes the order of fonts in the `font-family` list to put `"Twemoji Mozilla"` first. I'm just going to assume that, if Mozilla is bundling their own font in the browser, then they know what they're doing and they're shipping emoji updates faster than the underlying OS.

This assumption will break if the underlying OS emoji (i.e. Noto Emoji on Linux and Segoe UI on Windows) ever update faster than Mozilla Twemoji, but I guess we have to take that risk. Today Mozilla Twemoji is on v13.1, Segoe is on v12.1 (on my Windows 10 21H2), and Noto is on v13.1 (on my Ubuntu 20.04).

**Before:**

![Screenshot 2022-03-20 135322](https://user-images.githubusercontent.com/283842/159186431-58b7bddc-63f3-4e76-98d8-8eb649522500.png)
![Screenshot 2022-03-20 134437](https://user-images.githubusercontent.com/283842/159186437-489a1667-3318-4037-a96b-c4c54f4b7be3.png)
![Screenshot 2022-03-20 134457](https://user-images.githubusercontent.com/283842/159186442-1f08f3bc-b8dd-42d9-b806-f005ed474b69.png)


**After:**

![Screenshot 2022-03-20 140544](https://user-images.githubusercontent.com/283842/159186269-b0831329-7ddb-41f5-9b86-db91126c3bab.png)
![Screenshot 2022-03-20 140556](https://user-images.githubusercontent.com/283842/159186277-45968074-8691-4868-be8c-d03043f7c928.png)
![Screenshot 2022-03-20 140605](https://user-images.githubusercontent.com/283842/159186283-cee36470-576c-436a-b438-e63135614537.png)



MacOS and Android are unchanged because Mozilla doesn't ship Twemoji there. Linux is unchanged because we already listed Twemoji before Noto.