### PR TITLE
docs: add docs for native emoji fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -872,6 +872,49 @@ For browsers that don't support IndexedDB, such as [Firefox in private browsing 
 
 For Node.js environments such as [Jest](https://jestjs.io/) or [JSDom](https://github.com/jsdom/jsdom), you can also use fake-indexeddb. A [working example](https://github.com/nolanlawson/emoji-picker-element/blob/39c50c3ce4c4c4d2cd8a15f337a722ad86c739e9/config/jest.setup.js#L28-L29) can be found in the tests for this very project.
 
+## Using native emoji fonts
+
+If you're using emoji elsewhere in your website, and you want the emoji to exactly match the font used
+in `emoji-picker-element`, then add a CSS `font-family` that is
+[the same as the one used by `emoji-picker-element`](https://github.com/nolanlawson/emoji-picker-element/blob/master/src/picker/constants.js). For example:
+
+```css
+.my-emoji-class {
+  font-family: "Twemoji Mozilla","Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol",
+               "Noto Color Emoji","EmojiOne Color","Android Emoji",sans-serif;
+}
+```
+
+```html
+Hello <span class="my-emoji-class">🌍</span>!
+```
+
+To determine which spans of text to apply this `font-family` to (i.e. the `my-emoji-class` above), you can use a tool
+like [emoji-regex](https://www.npmjs.com/package/emoji-regex).
+
+Or, if you don't want to process text in JavaScript, you could use
+[emoji-unicode-range](https://www.npmjs.com/package/emoji-unicode-range) with a custom `@font-face`:
+
+```css
+@font-face {
+    font-family: MyEmojiFont;
+    src:
+        local("Twemoji Mozilla"),
+        local("Apple Color Emoji"),
+        local("Segoe UI Emoji"),
+        local("Segoe UI Symbol"),
+        local("Noto Color Emoji"),
+        local("EmojiOne Color"),
+        local("Android Emoji");
+    unicode-range: /* copy from emoji-unicode-range */;
+}
+body {
+    font-family: MyEmojiFont, sans-serif;
+}
+```
+
+Here is [a demo](https://bl.ocks.org/nolanlawson/61e10fab056e75b02b5c6a0a223a5ad7).
+
 ## Design decisions
 
 Some of the reasoning behind why `emoji-picker-element` is built the way it is.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ A lightweight emoji picker, distributed as a web component.
     + [Trimming the emoji data (deprecated)](#trimming-the-emoji-data-deprecated)
     + [Offline-first](#offline-first)
     + [Environments without IndexedDB](#environments-without-indexeddb)
+  * [Using native emoji fonts](#using-native-emoji-fonts)
   * [Design decisions](#design-decisions)
     + [IndexedDB](#indexeddb)
     + [Native emoji](#native-emoji)

--- a/README.md
+++ b/README.md
@@ -898,19 +898,19 @@ Or, if you don't want to process text in JavaScript, you could use
 
 ```css
 @font-face {
-    font-family: MyEmojiFont;
-    src:
-        local("Twemoji Mozilla"),
-        local("Apple Color Emoji"),
-        local("Segoe UI Emoji"),
-        local("Segoe UI Symbol"),
-        local("Noto Color Emoji"),
-        local("EmojiOne Color"),
-        local("Android Emoji");
-    unicode-range: /* copy from emoji-unicode-range */;
+  font-family: MyEmojiFont;
+  src:
+    local("Twemoji Mozilla"),
+    local("Apple Color Emoji"),
+    local("Segoe UI Emoji"),
+    local("Segoe UI Symbol"),
+    local("Noto Color Emoji"),
+    local("EmojiOne Color"),
+    local("Android Emoji");
+  unicode-range: /* copy from emoji-unicode-range */;
 }
 body {
-    font-family: MyEmojiFont, sans-serif;
+  font-family: MyEmojiFont, sans-serif;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -899,14 +899,13 @@ Or, if you don't want to process text in JavaScript, you could use
 ```css
 @font-face {
   font-family: MyEmojiFont;
-  src:
-    local("Twemoji Mozilla"),
-    local("Apple Color Emoji"),
-    local("Segoe UI Emoji"),
-    local("Segoe UI Symbol"),
-    local("Noto Color Emoji"),
-    local("EmojiOne Color"),
-    local("Android Emoji");
+  src: local("Twemoji Mozilla"),
+       local("Apple Color Emoji"),
+       local("Segoe UI Emoji"),
+       local("Segoe UI Symbol"),
+       local("Noto Color Emoji"),
+       local("EmojiOne Color"),
+       local("Android Emoji");
   unicode-range: /* copy from emoji-unicode-range */;
 }
 body {


### PR DESCRIPTION
As mentioned in https://github.com/nolanlawson/emoji-picker-element/pull/271#issuecomment-1073352988, it's really non-obvious how to make your own fonts match `emoji-picker-element`'s fonts (e.g. when using emoji elsewhere on your website). This adds some documentation to the README about how to handle that.

I haven't extensively tested the `unicode-range` approach, but based on [a demo](https://bl.ocks.org/nolanlawson/61e10fab056e75b02b5c6a0a223a5ad7) I wrote, it seems to work fairly well cross-browser and cross-OS. `emoji-regex` is probably the more well-maintained approach, so I mentioned that as well.