### PR TITLE
fix: remove aria-owns

### DIFF
--- a/src/picker/components/Picker/Picker.html
+++ b/src/picker/components/Picker/Picker.html
@@ -22,7 +22,6 @@
         spellcheck="true"
         aria-expanded={!!(searchMode && currentEmojis.length)}
         aria-controls="search-results"
-        aria-owns="search-results"
         aria-describedby="search-description"
         aria-autocomplete="list"
         aria-activedescendant={activeSearchItemId ? `emo-${activeSearchItemId}` : ''}


### PR DESCRIPTION
I added this in #19. After reading [a bit more](https://tink.uk/using-the-aria-owns-attribute/) about `aria-owns`, and now that aXe is no longer warning about this, I don't think this is necessary. There is no difference in NVDA or VoiceOver when adding this, and I think semantically it's wrong anyhow. (The listbox can't be a child of the input… I think I was confused because in [the ARIA combobox example](https://www.w3.org/TR/wai-aria-practices-1.1/examples/combobox/aria1.1pattern/listbox-combo.html) the combobox wrapper `aria-own`s the listbox, but in the notes they say that that's just to place the listbox directly after the input (which is also a child of the wrapper). I'm not too concerned about the ordering being off (because you're not meant to tab to the search results anyway; you're meant to hit up and down on the keyboard), so let's just remove this.