### PR TITLE
perf: trim unused svelte options

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -49,7 +49,11 @@ const baseConfig = {
     }),
     // make the svelte output slightly smaller
     replace({
-      'options.hydrate': 'false',
+      'options.anchor': 'undefined',
+      'options.context': 'undefined',
+      'options.customElement': 'undefined',
+      'options.hydrate': 'undefined',
+      'options.intro': 'undefined',
       delimiters: ['', ''],
       preventAssignment: true
     }),


### PR DESCRIPTION
This reduces the bundle size a small amount, even if it's not much.