### PR TITLE
Add `getAllNativeEmojis` to database

### DIFF
--- a/database.d.ts
+++ b/database.d.ts
@@ -79,6 +79,10 @@ export default class Database {
      */
     getTopFavoriteEmoji(limit: number): Promise<Emoji[]>;
     /**
+     * Returns all native emojis, unordered.
+     */
+    getAllNativeEmojis(): Promise<NativeEmoji[]>;
+    /**
      * Set the custom emoji for this database. Throws an error if custom emoji are not in the correct format.
      *
      *

--- a/src/database/Database.js
+++ b/src/database/Database.js
@@ -14,7 +14,7 @@ import {
   openDatabase
 } from './databaseLifecycle'
 import {
-  isEmpty, getEmojiByGroup,
+  isEmpty, getAllNativeEmojis, getEmojiByGroup,
   getEmojiBySearchQuery, getEmojiByShortcode, getEmojiByUnicode,
   get, set, getTopFavoriteEmoji, incrementFavoriteEmojiCount
 } from './idbInterface'
@@ -123,6 +123,11 @@ export default class Database {
     assertNumber(limit)
     await this.ready()
     return (await getTopFavoriteEmoji(this._db, this._custom, limit)).map(cleanEmoji)
+  }
+
+  async getAllNativeEmojis () {
+    await this.ready()
+    return (await getAllNativeEmojis(this._db)).map(cleanEmoji)
   }
 
   set customEmoji (customEmojis) {

--- a/src/database/idbInterface.js
+++ b/src/database/idbInterface.js
@@ -241,3 +241,9 @@ export function getTopFavoriteEmoji (db, customEmojiIndex, limit) {
     }
   })
 }
+
+export async function getAllNativeEmojis (db) {
+  return dbPromise(db, STORE_EMOJI, MODE_READONLY, (emojiStore, txn, cb) => {
+    getAllIDB(emojiStore.index(INDEX_GROUP_AND_ORDER), undefined, cb)
+  })
+}

--- a/test/spec/database/getAllNativeEmojis.test.js
+++ b/test/spec/database/getAllNativeEmojis.test.js
@@ -1,0 +1,13 @@
+import { ALL_EMOJI, basicAfterEach, basicBeforeEach } from '../shared'
+import Database from '../../../src/database/Database'
+
+describe('getAllNativeEmojis', () => {
+  beforeEach(basicBeforeEach)
+  afterEach(basicAfterEach)
+  test('basic test', async () => {
+    const db = new Database({ dataSource: ALL_EMOJI })
+
+    expect((await db.getAllNativeEmojis()).length).toBe(189)
+    await db.delete()
+  })
+})


### PR DESCRIPTION
We have a use case where we'd like to synchronously determine if a string is a single emoji.

By adding `getAllNativeEmojis`, we can load all of the emoji unicode strings into a Set, solving our problem.