### PR TITLE
perf: avoid recreating excessive empty objects

### DIFF
--- a/src/database/Database.js
+++ b/src/database/Database.js
@@ -21,9 +21,10 @@ import {
 import { customEmojiIndex } from './customEmojiIndex'
 import { cleanEmoji } from './utils/cleanEmoji'
 import { loadDataForFirstTime, checkForUpdates } from './dataLoading'
+import { EMPTY_ARRAY, EMPTY_OBJECT } from '../shared/lang.js'
 
 export default class Database {
-  constructor ({ dataSource = DEFAULT_DATA_SOURCE, locale = DEFAULT_LOCALE, customEmoji = [] } = {}) {
+  constructor ({ dataSource = DEFAULT_DATA_SOURCE, locale = DEFAULT_LOCALE, customEmoji = EMPTY_ARRAY } = EMPTY_OBJECT) {
     this.dataSource = dataSource
     this.locale = locale
     this._dbName = `emoji-picker-element-${this.locale}`

--- a/src/database/customEmojiIndex.js
+++ b/src/database/customEmojiIndex.js
@@ -2,6 +2,7 @@ import { trie } from './utils/trie'
 import { extractTokens } from './utils/extractTokens'
 import { assertCustomEmojis } from './utils/assertCustomEmojis'
 import { findCommonMembers } from './utils/findCommonMembers'
+import { EMPTY_ARRAY } from '../shared/lang.js'
 
 export function customEmojiIndex (customEmojis) {
   assertCustomEmojis(customEmojis)
@@ -17,7 +18,7 @@ export function customEmojiIndex (customEmojis) {
   // search()
   //
   const emojiToTokens = emoji => (
-    [...new Set((emoji.shortcodes || []).map(shortcode => extractTokens(shortcode)).flat())]
+    [...new Set((emoji.shortcodes || EMPTY_ARRAY).map(shortcode => extractTokens(shortcode)).flat())]
   )
   const searchTrie = trie(customEmojis, emojiToTokens)
   const searchByExactMatch = _ => searchTrie(_, true)
@@ -41,7 +42,7 @@ export function customEmojiIndex (customEmojis) {
   const nameToEmoji = new Map()
   for (const customEmoji of customEmojis) {
     nameToEmoji.set(customEmoji.name.toLowerCase(), customEmoji)
-    for (const shortcode of (customEmoji.shortcodes || [])) {
+    for (const shortcode of (customEmoji.shortcodes || EMPTY_ARRAY)) {
       shortcodeToEmoji.set(shortcode.toLowerCase(), customEmoji)
     }
   }

--- a/src/database/idbInterface.js
+++ b/src/database/idbInterface.js
@@ -11,6 +11,7 @@ import { extractTokens } from './utils/extractTokens'
 import { commit, getAllIDB, getIDB } from './idbUtil'
 import { findCommonMembers } from './utils/findCommonMembers'
 import { normalizeTokens } from './utils/normalizeTokens'
+import { EMPTY_ARRAY } from '../shared/lang.js'
 
 export async function isEmpty (db) {
   return !(await get(db, STORE_KEYVALUE, KEY_URL))
@@ -119,7 +120,7 @@ export async function getEmojiBySearchQuery (db, query) {
   const tokens = normalizeTokens(extractTokens(query))
 
   if (!tokens.length) {
-    return []
+    return EMPTY_ARRAY
   }
 
   return dbPromise(db, STORE_EMOJI, MODE_READONLY, (emojiStore, txn, cb) => {
@@ -161,12 +162,12 @@ export async function getEmojiByShortcode (db, shortcode) {
   // index on shortcodes.
 
   if (!emojis.length) {
-    const predicate = _ => ((_.shortcodes || []).includes(shortcode.toLowerCase()))
+    const predicate = _ => ((_.shortcodes || EMPTY_ARRAY).includes(shortcode.toLowerCase()))
     return (await doFullDatabaseScanForSingleResult(db, predicate)) || null
   }
 
   return emojis.filter(_ => {
-    const lowerShortcodes = (_.shortcodes || []).map(_ => _.toLowerCase())
+    const lowerShortcodes = (_.shortcodes || EMPTY_ARRAY).map(_ => _.toLowerCase())
     return lowerShortcodes.includes(shortcode.toLowerCase())
   })[0] || null
 }
@@ -206,7 +207,7 @@ export function incrementFavoriteEmojiCount (db, unicode) {
 
 export function getTopFavoriteEmoji (db, customEmojiIndex, limit) {
   if (limit === 0) {
-    return []
+    return EMPTY_ARRAY
   }
   return dbPromise(db, [STORE_FAVORITES, STORE_EMOJI], MODE_READONLY, ([favoritesStore, emojiStore], txn, cb) => {
     const results = []

--- a/src/database/utils/transformEmojiData.js
+++ b/src/database/utils/transformEmojiData.js
@@ -1,5 +1,6 @@
 import { extractTokens } from './extractTokens'
 import { normalizeTokens } from './normalizeTokens'
+import { EMPTY_ARRAY } from '../../shared/lang.js'
 
 // Transform emoji data for storage in IDB
 export function transformEmojiData (emojiData) {
@@ -7,7 +8,7 @@ export function transformEmojiData (emojiData) {
   const res = emojiData.map(({ annotation, emoticon, group, order, shortcodes, skins, tags, emoji, version }) => {
     const tokens = [...new Set(
       normalizeTokens([
-        ...(shortcodes || []).map(extractTokens).flat(),
+        ...(shortcodes || EMPTY_ARRAY).map(extractTokens).flat(),
         ...tags.map(extractTokens).flat(),
         ...extractTokens(annotation),
         emoticon

--- a/src/database/utils/trie.js
+++ b/src/database/utils/trie.js
@@ -1,6 +1,8 @@
 // trie data structure for prefix searches
 // loosely based on https://github.com/nolanlawson/substring-trie
 
+import { EMPTY_ARRAY } from '../../shared/lang.js'
+
 const CODA_MARKER = '' // marks the end of the string
 
 export function trie (arr, itemToTokens) {
@@ -35,13 +37,13 @@ export function trie (arr, itemToTokens) {
       if (nextMap) {
         currentMap = nextMap
       } else {
-        return []
+        return EMPTY_ARRAY
       }
     }
 
     if (exact) {
       const results = currentMap.get(CODA_MARKER)
-      return results || []
+      return results || EMPTY_ARRAY
     }
 
     const results = []

--- a/src/picker/utils/resetScrollTopIfPossible.js
+++ b/src/picker/utils/resetScrollTopIfPossible.js
@@ -1,0 +1,11 @@
+// Reset scroll top to 0 when emojis change
+// Note we put this in its own function outside Picker.js to avoid Svelte doing an invalidation on the "setter" here.
+// At best the invalidation is useless, at worst it can cause infinite loops:
+// https://github.com/nolanlawson/emoji-picker-element/pull/180
+// https://github.com/sveltejs/svelte/issues/6521
+// Also note tabpanelElement can be null if the element is disconnected immediately after connected
+export function resetScrollTopIfPossible (element) {
+  if (element) {
+    element.scrollTop = 0
+  }
+}

--- a/src/shared/lang.js
+++ b/src/shared/lang.js
@@ -2,6 +2,7 @@
 export const EMPTY_ARRAY = []
 export const EMPTY_OBJECT = {}
 
+/* istanbul ignore else */
 if (process.env.NODE_ENV !== 'production') {
   // In dev/test mode, we want to know if we are accidentally mutating these. Throw an error on mutation.
   Object.freeze(EMPTY_ARRAY)

--- a/src/shared/lang.js
+++ b/src/shared/lang.js
@@ -1,0 +1,8 @@
+// Avoid using a bunch of extra memory for throwaway read-only empty objects/arrays
+export const EMPTY_ARRAY = []
+export const EMPTY_OBJECT = {}
+
+if (process.env.NODE_ENV !== 'production') {
+  Object.freeze(EMPTY_ARRAY)
+  Object.freeze(EMPTY_OBJECT)
+}

--- a/src/shared/lang.js
+++ b/src/shared/lang.js
@@ -3,6 +3,7 @@ export const EMPTY_ARRAY = []
 export const EMPTY_OBJECT = {}
 
 if (process.env.NODE_ENV !== 'production') {
+  // In dev/test mode, we want to know if we are accidentally mutating these. Throw an error on mutation.
   Object.freeze(EMPTY_ARRAY)
   Object.freeze(EMPTY_OBJECT)
 }


### PR DESCRIPTION
Avoids some memory churn by not recreating empty objects and arrays in several places.

This introduces some risk in that we might leak these objects outside of the picker/database, and if people mutate them, then they could change the behavior. But people might already have a bad time if they mutate the objects returned from the database/picker – it's not something I've tested in the past.