### PR TITLE
fix: simpler solution to avoid svelte invalidations

### DIFF
--- a/src/picker/components/Picker/Picker.js
+++ b/src/picker/components/Picker/Picker.js
@@ -303,6 +303,7 @@ $: {
     requestAnimationFrame(() => checkZwjSupportAndUpdate(zwjEmojisToCheck))
   } else {
     currentEmojis = currentEmojis.filter(isZwjSupported)
+    // Reset scroll top to 0 when emojis change
     requestAnimationFrame(() => resetScrollTopIfPossible(tabpanelElement))
   }
 }

--- a/src/picker/components/Picker/Picker.js
+++ b/src/picker/components/Picker/Picker.js
@@ -22,6 +22,7 @@ import { requestPostAnimationFrame } from '../../utils/requestPostAnimationFrame
 import { tick } from 'svelte'
 import { requestAnimationFrame } from '../../utils/requestAnimationFrame'
 import { uniq } from '../../../shared/uniq'
+import { resetScrollTopIfPossible } from '../../utils/resetScrollTopIfPossible.js'
 
 // public
 export let skinToneEmoji
@@ -302,15 +303,7 @@ $: {
     requestAnimationFrame(() => checkZwjSupportAndUpdate(zwjEmojisToCheck))
   } else {
     currentEmojis = currentEmojis.filter(isZwjSupported)
-    requestAnimationFrame(() => {
-      // Avoid Svelte doing an invalidation on the "setter" here.
-      // At best the invalidation is useless, at worst it can cause infinite loops:
-      // https://github.com/nolanlawson/emoji-picker-element/pull/180
-      // https://github.com/sveltejs/svelte/issues/6521
-      // Also note tabpanelElement can be null if the element is disconnected
-      // immediately after connected, hence `|| {}`
-      (tabpanelElement || {}).scrollTop = 0 // reset scroll top to 0 when emojis change
-    })
+    requestAnimationFrame(() => resetScrollTopIfPossible(tabpanelElement))
   }
 }
 

--- a/src/picker/utils/resetScrollTopIfPossible.js
+++ b/src/picker/utils/resetScrollTopIfPossible.js
@@ -1,0 +1,11 @@
+// Reset scroll top to 0 when emojis change
+// Note we put this in its own function outside Picker.js to avoid Svelte doing an invalidation on the "setter" here.
+// At best the invalidation is useless, at worst it can cause infinite loops:
+// https://github.com/nolanlawson/emoji-picker-element/pull/180
+// https://github.com/sveltejs/svelte/issues/6521
+// Also note tabpanelElement can be null if the element is disconnected immediately after connected
+export function resetScrollTopIfPossible (element) {
+  if (element) {
+    element.scrollTop = 0
+  }
+}

--- a/src/picker/utils/resetScrollTopIfPossible.js
+++ b/src/picker/utils/resetScrollTopIfPossible.js
@@ -1,4 +1,3 @@
-// Reset scroll top to 0 when emojis change
 // Note we put this in its own function outside Picker.js to avoid Svelte doing an invalidation on the "setter" here.
 // At best the invalidation is useless, at worst it can cause infinite loops:
 // https://github.com/nolanlawson/emoji-picker-element/pull/180


### PR DESCRIPTION
Moving to a function outside of the Svelte component avoids Svelte adding invalidations