### PR TITLE
fix: simplify skintone listbox

### DIFF
--- a/src/picker/components/Picker/Picker.html
+++ b/src/picker/components/Picker/Picker.html
@@ -31,8 +31,13 @@
       <label class="sr-only" for="search">{i18n.searchLabel}</label>
       <span id="search-description" class="sr-only">{i18n.searchDescription}</span>
     </div>
-    <!-- For the pattern used for the skintone dropdown, see
-         https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-select-only/ -->
+    <!-- For the pattern used for the skintone dropdown, see:
+         https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-select-only/
+         The one case where we deviate from the example is that we move focus from the button to the
+         listbox. (The example uses a combobox, so it's not exactly the same.) This was tested in NVDA and VoiceOver.
+         Note that Svelte's a11y checker will warn if the listbox does not have a tabindex.
+         https://github.com/sveltejs/svelte/blob/3bc791b/site/content/docs/06-accessibility-warnings.md#a11y-aria-activedescendant-has-tabindex
+         -->
     <div class="skintone-button-wrapper {skinTonePickerExpandedAfterAnimation ? 'expanded' : ''}">
       <button id="skintone-button"
               class="emoji {skinTonePickerExpanded ? 'hide-focus' : ''}"
@@ -47,31 +52,25 @@
       </button>
     </div>
     <span id="skintone-description" class="sr-only">{i18n.skinToneDescription}</span>
-    <!-- In this pattern, the listbox is not focusable, only the button is focusable.
-         This was tested in NVDA and VoiceOver and worked in both. -->
-    <!-- svelte-ignore a11y-aria-activedescendant-has-tabindex -->
     <div id="skintone-list"
-         class="skintone-list {skinTonePickerExpanded ? '' : 'hidden no-animate'}"
+         class="skintone-list hide-focus {skinTonePickerExpanded ? '' : 'hidden no-animate'}"
          style="transform:translateY({ skinTonePickerExpanded ? 0 : 'calc(-1 * var(--num-skintones) * var(--total-emoji-size))'})"
          role="listbox"
          aria-label={i18n.skinTonesLabel}
          aria-activedescendant="skintone-{activeSkinTone}"
          aria-hidden={!skinTonePickerExpanded}
+         tabindex="-1"
          on:focusout={onSkinToneOptionsFocusOut}
          on:click={onSkinToneOptionsClick}
          on:keydown={onSkinToneOptionsKeydown}
          on:keyup={onSkinToneOptionsKeyup}
          bind:this={skinToneDropdown}>
       {#each skinTones as skinTone, i (skinTone)}
-        <!-- would use a button here, but iOS Safari misreports relatedTarget in that case, see issue #14 -->
-        <!-- see https://stackoverflow.com/a/42764495/680742 -->
-        <!-- see also https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus -->
         <div    id="skintone-{i}"
-                class="emoji hide-focus {i === activeSkinTone ? 'active' : ''}"
+                class="emoji {i === activeSkinTone ? 'active' : ''}"
                 aria-selected={i === activeSkinTone}
                 role="option"
                 title={i18n.skinTones[i]}
-                tabindex="-1"
                 aria-label={i18n.skinTones[i]}>
           {skinTone}
         </div>

--- a/test/spec/picker/Picker.test.js
+++ b/test/spec/picker/Picker.test.js
@@ -21,7 +21,7 @@ describe('Picker tests', () => {
       }
     }
   })
-  const { getAllByRole, getByRole, queryAllByRole } = proxy
+  const { getAllByRole, getByRole, queryAllByRole, queryByRole } = proxy
 
   const activeElement = () => container.getRootNode().activeElement
 
@@ -85,13 +85,23 @@ describe('Picker tests', () => {
     })
 
     await openSkintoneListbox(container)
-    await waitFor(() => expect(getByRole('option', { name: 'Default', selected: true }))
-      .toBe(activeElement()))
+
+    await waitFor(() => (
+      expect(
+        getByRole('option', { name: 'Default', selected: true }).id)
+        .toBe(queryByRole('listbox', { name: 'Skin tones' }).getAttribute('aria-activedescendant'))
+    )
+    )
 
     const pressKeyAndExpectActiveOption = async (key, name) => {
       await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve))) // delay
       await fireEvent.keyDown(activeElement(), { key, code: key })
-      await waitFor(() => expect(getByRole('option', { name, selected: true })).toBe(activeElement()))
+      await waitFor(() => {
+        const selectedOption = getByRole('option', { name, selected: true })
+        return expect(selectedOption.id).toBe(
+          queryByRole('listbox', { name: 'Skin tones' }).getAttribute('aria-activedescendant')
+        )
+      })
     }
 
     await pressKeyAndExpectActiveOption('ArrowDown', 'Light')
@@ -106,7 +116,7 @@ describe('Picker tests', () => {
     await pressKeyAndExpectActiveOption('End', 'Dark')
     await pressKeyAndExpectActiveOption('End', 'Dark')
 
-    await fireEvent.click(activeElement(), { key: 'Enter', code: 'Enter' })
+    await fireEvent.keyDown(activeElement(), { key: 'Enter', code: 'Enter' })
 
     await waitFor(() => expect(event && event.detail).toStrictEqual({ skinTone: 5 }))
     await waitFor(() => expect(queryAllByRole('listbox', { name: 'Skin tones' })).toHaveLength(0))
@@ -152,8 +162,12 @@ describe('Picker tests', () => {
 
   test('Escape key dismisses skintone listbox', async () => {
     await openSkintoneListbox(container)
-    await waitFor(() => expect(getByRole('option', { name: 'Default', selected: true }))
-      .toBe(activeElement()))
+    await waitFor(() => (
+      expect(
+        getByRole('option', { name: 'Default', selected: true }).id)
+        .toBe(queryByRole('listbox', { name: 'Skin tones' }).getAttribute('aria-activedescendant'))
+    )
+    )
 
     await fireEvent.keyDown(activeElement(), { key: 'Escape', code: 'Escape' })
 

--- a/test/spec/picker/Picker.test.js
+++ b/test/spec/picker/Picker.test.js
@@ -354,12 +354,21 @@ describe('Picker tests', () => {
     await waitFor(() => expect(emoji && emoji.name === 'donkey'))
   }, 5000)
 
-  // TODO: re-enable this behavior. See https://github.com/nolanlawson/emoji-picker-element/issues/14
   test('Closes skintone picker when blurred', async () => {
     fireEvent.click(getByRole('button', { name: /Choose a skin tone/ }))
     await waitFor(() => expect(getByRole('listbox', { name: 'Skin tones' })).toBeVisible())
     // Simulating a focusout event is hard, have to both focus and blur
     getByRole('combobox').focus()
+    fireEvent.focusOut(getByRole('listbox', { name: 'Skin tones' }))
+    await waitFor(() => expect(queryAllByRole('listbox', { name: 'Skin tones' })).toHaveLength(0))
+  })
+
+  test('Closes skintone picker when focus moves to skintone trigger button', async () => {
+    const chooseSkintoneButton = getByRole('button', { name: /Choose a skin tone/ })
+    fireEvent.click(chooseSkintoneButton)
+    await waitFor(() => expect(getByRole('listbox', { name: 'Skin tones' })).toBeVisible())
+    // Simulating a focusout event is hard, have to both focus and blur
+    chooseSkintoneButton.focus()
     fireEvent.focusOut(getByRole('listbox', { name: 'Skin tones' }))
     await waitFor(() => expect(queryAllByRole('listbox', { name: 'Skin tones' })).toHaveLength(0))
   })

--- a/test/spec/picker/shared.js
+++ b/test/spec/picker/shared.js
@@ -16,6 +16,11 @@ export async function openSkintoneListbox (container) {
   // JSDom doesn't fire transitionend events, so we do it manually here
   // https://github.com/jsdom/jsdom/issues/1781#issuecomment-467935000
   fireEvent(getByRole(container, 'listbox', { name: 'Skin tones' }), new Event('transitionend'))
+
+  await waitFor(() => (
+    expect(container.getRootNode().activeElement)
+      .toBe(getByRole(container, 'listbox', { name: 'Skin tones' }))
+  ))
 }
 
 export function checkEmojiEquals (actual, expected) {


### PR DESCRIPTION
Fixes #335

After upgrading Svelte, I noticed a new accessibility [warning](https://github.com/sveltejs/svelte/blob/3bc791b/site/content/docs/06-accessibility-warnings.md#a11y-aria-activedescendant-has-tabindex) about how `activedescendant` elements should have `tabindex`. I looked into it, and decided I could simplify the skintone picker by abiding by this rule.

Tested in various screenreaders/browsers, the behavior is the same as before, but I was able to clean up the code a bit and get rid of the warning. I also went ahead and fixed #335 because I noticed it.

- NVDA+Firefox
- NVDA+Chrome
- VoiceOver+Safari
- VoiceOver+Chrome