### PR TITLE
chore: fix storage tests in webkit

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "emojibase-data": "^5.1.1",
     "express": "^4.18.2",
     "fake-indexeddb": "^5.0.1",
+    "fast-glob": "^3.3.2",
     "fetch-mock-jest": "^1.5.1",
     "flat-color-icons": "^1.1.0",
     "focus-visible": "^5.2.0",

--- a/test/storage/test.js
+++ b/test/storage/test.js
@@ -1,7 +1,8 @@
+import glob from 'fast-glob'
 import playwright from 'playwright'
 import { mkdirp, rimraf } from '../../bin/fs.js'
 import getFolderSize from 'get-folder-size'
-import path from 'path'
+import path from 'node:path'
 import prettyBytes from 'pretty-bytes'
 import { markdownTable as table } from 'markdown-table'
 import process from 'process'
@@ -19,7 +20,9 @@ function getIdbFolder (browserType, userDataDir) {
     case 'firefox':
       return path.join(userDataDir, `storage/default/http+++localhost+${port}/idb`)
     case 'webkit':
-      return path.join(userDataDir, `databases/indexeddb/v1/http_localhost_${port}`)
+      // IDB is stored in what appears to be a checksum-encoded folder, e.g.:
+      // storage/<checksum>-<checksum>/<checksum>-<checksum>/IndexedDB/<checksum>/
+      return path.dirname(glob.sync(path.join(userDataDir, 'storage/**/**/IndexedDB/**'))[0])
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3196,6 +3196,17 @@ fast-glob@^3.2.9, fast-glob@^3.3.1:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
+fast-glob@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.2.tgz#a904501e57cfdd2ffcded45e99a54fef55e46129"
+  integrity sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
 fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"


### PR DESCRIPTION
Guess WebKit changed where IDB data is stored.