### PR TITLE
Replace optional chaining for `ensure_array_like_shim`

### DIFF
--- a/shims/svelte-v3-shim.js
+++ b/shims/svelte-v3-shim.js
@@ -3,7 +3,7 @@
 // this code is copied from svelte v4
 /* eslint-disable camelcase */
 export function ensure_array_like_shim (array_like_or_iterator) {
-  return array_like_or_iterator?.length !== undefined
+  return array_like_or_iterator && array_like_or_iterator.length !== undefined
     ? array_like_or_iterator
     : Array.from(array_like_or_iterator)
 }


### PR DESCRIPTION
Hey hey !

In the v1.19, a new function was introduced (`ensure_array_like_shim`)

But this function isn't transpiled in the final bundle. The optional chaining operator `?.` was introduced in Safari 13.4, which is not that old, so this triggers errors [on a few browsers ](https://caniuse.com/mdn-javascript_operators_optional_chaining).

I'm not very familiar with rollup so maybe there are ways to transpile the code injected via the `inject` plugin, which would be more robust ?