### PR TITLE
fix: avoid newer JS syntax to support old Safari

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -80,10 +80,12 @@ const entryPoints = [
     input: './src/picker/PickerElement.js',
     output: './picker.js',
     plugins: [
-      // Replace optional chaining in Svelte ensure_array_like function to avoid breaking iOS <13.4
+      // Replace newer syntax in Svelte v4 to avoid breaking iOS <13.4
       // https://github.com/nolanlawson/emoji-picker-element/pull/379
       replace({
         'array_like_or_iterator?.length': 'array_like_or_iterator && array_like_or_iterator.length',
+        '$$ = undefined;': '', // not necessary to initialize class prop to undefined
+        '$$set = undefined;': '', // not necessary to initialize class prop to undefined
         delimiters: ['', ''],
         preventAssignment: true
       })

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -78,7 +78,16 @@ const baseConfig = {
 const entryPoints = [
   {
     input: './src/picker/PickerElement.js',
-    output: './picker.js'
+    output: './picker.js',
+    plugins: [
+      // Replace optional chaining in Svelte ensure_array_like function to avoid breaking iOS <13.4
+      // https://github.com/nolanlawson/emoji-picker-element/pull/379
+      replace({
+        'array_like_or_iterator?.length': 'array_like_or_iterator && array_like_or_iterator.length',
+        delimiters: ['', ''],
+        preventAssignment: true
+      })
+    ]
   },
   {
     input: './src/database/Database.js',

--- a/shims/svelte-v3-shim.js
+++ b/shims/svelte-v3-shim.js
@@ -3,7 +3,7 @@
 // this code is copied from svelte v4
 /* eslint-disable camelcase */
 export function ensure_array_like_shim (array_like_or_iterator) {
-  return array_like_or_iterator?.length !== undefined
+  return (array_like_or_iterator && array_like_or_iterator.length !== undefined)
     ? array_like_or_iterator
     : Array.from(array_like_or_iterator)
 }


### PR DESCRIPTION
Fixes #379

Avoids breaking old browsers by avoiding the optional chaining (`?.`) syntax.