### PR TITLE
feat: add support for emoji v15.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A lightweight emoji picker, distributed as a web component.
 
 **Features:**
 
-- Supports [Emoji v15.0](https://emojipedia.org/emoji-15.0/) (depending on OS) and custom emoji
+- Supports [Emoji v15.1](https://emojipedia.org/emoji-15.1/) (depending on OS) and custom emoji
 - Uses IndexedDB, so it consumes [far less memory](https://nolanlawson.com/2020/06/28/introducing-emoji-picker-element-a-memory-efficient-emoji-picker-for-the-web/) than other emoji pickers
 - [Small bundle size](https://bundlephobia.com/result?p=emoji-picker-element) (<15kB min+gz)
 - Renders native emoji by default, with support for custom fonts

--- a/bin/versionsAndTestEmoji.js
+++ b/bin/versionsAndTestEmoji.js
@@ -8,7 +8,7 @@
 // "face without mouth" plus "fog".) These emoji can only be filtered using the width test,
 // which happens in checkZwjSupport.js.
 export const versionsAndTestEmoji = {
-  '🫨': 15,
+  '🫨': 15.1, // shaking head, technically from v15 but see note above
   '🫠': 14,
   '🥲': 13.1, // smiling face with tear, technically from v13 but see note above
   '🥻': 12.1, // sari, technically from v12 but see note above

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "cross-env": "^7.0.3",
     "csso": "^5.0.2",
     "d2l-resize-aware": "github:BrightspaceUI/resize-aware#semver:^1.2.2",
-    "emoji-picker-element-data": "^1.5.0",
+    "emoji-picker-element-data": "^1.6.0",
     "emojibase-data": "^5.1.1",
     "express": "^4.18.2",
     "fake-indexeddb": "^5.0.1",

--- a/test/spec/database/custom.test.js
+++ b/test/spec/database/custom.test.js
@@ -163,7 +163,7 @@ describe('custom emoji', () => {
       '✌️': 8,
       '🐶': 9,
       '🎉': 3,
-      '✨': 3,
+      '✨️': 3,
       CapitalLettersLikeThis: 3,
       underscores_like_this: 6,
       monkey: 5
@@ -184,7 +184,7 @@ describe('custom emoji', () => {
       { name: 'monkey', shortcodes: ['monkey'], url: 'monkey.png' },
       summaryByUnicode('🐒'),
       summaryByUnicode('🎉'),
-      summaryByUnicode('✨'),
+      summaryByUnicode('✨️'),
       { name: 'CapitalLettersLikeThis', shortcodes: ['CapitalLettersLikeThis'], url: 'caps.png' }
     ])
 
@@ -197,7 +197,7 @@ describe('custom emoji', () => {
       { name: 'monkey', shortcodes: ['monkey'], url: 'monkey.png' },
       summaryByUnicode('🐒'),
       summaryByUnicode('🎉'),
-      summaryByUnicode('✨'),
+      summaryByUnicode('✨️'),
       { name: 'CapitalLettersLikeThis', shortcodes: ['CapitalLettersLikeThis'], url: 'caps.png' },
       summaryByUnicode('🤣'),
       summaryByUnicode('🖐️')
@@ -212,7 +212,7 @@ describe('custom emoji', () => {
       summaryByUnicode('🐵'),
       summaryByUnicode('🐒'),
       summaryByUnicode('🎉'),
-      summaryByUnicode('✨'),
+      summaryByUnicode('✨️'),
       summaryByUnicode('🤣'),
       summaryByUnicode('🖐️')
     ])

--- a/test/spec/database/favsAndSkinTone.test.js
+++ b/test/spec/database/favsAndSkinTone.test.js
@@ -44,7 +44,7 @@ describe('database tests', () => {
 
   test('emoji favorite counts', async () => {
     await db.incrementFavoriteEmojiCount('🐵')
-    const emojis = ['🐒', '😀', '🐵', '😅', '🤣', '🖐️', '🤏', '✌️', '🐶', '🎉', '✨']
+    const emojis = ['🐒', '😀', '🐵', '😅', '🤣', '🖐️', '🤏', '✌️', '🐶', '🎉', '✨️']
 
     for (let i = 0; i < emojis.length; i++) {
       for (let j = 0; j < emojis.length - i + 1; j++) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2621,10 +2621,10 @@ emittery@^0.13.1:
   resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.13.1.tgz#c04b8c3457490e0847ae51fced3af52d338e3dad"
   integrity sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==
 
-emoji-picker-element-data@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/emoji-picker-element-data/-/emoji-picker-element-data-1.5.0.tgz#bb6c1b150e856000d1ae291118e729d32e75b7ab"
-  integrity sha512-2lqImCs/lscLT5+ydNdiV9vLq2/lpTOqQ8ZldwxnVcqSAi4AY0HKNU+gf2RxgFQS7n0V9yhyl+J81ltmAVOeaw==
+emoji-picker-element-data@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/emoji-picker-element-data/-/emoji-picker-element-data-1.6.0.tgz#dba55004cbed96847b630e7e9266cae029ecc418"
+  integrity sha512-ktd7aW5yP8CDmdY4VDo7u1fWDfoSIunVNLBqCCK6wo0E2nxMaPlXG5CzXezCc1LhZIUWisF6OwHhveUCsmzJYQ==
 
 emoji-regex@^8.0.0:
   version "8.0.0"


### PR DESCRIPTION
Adds support for [emoji v15.1](https://emojipedia.org/emoji-15.1) with 🐦‍🔥 (phoenix) and 🙂‍↔️ (shaking head) among others.

See also https://github.com/nolanlawson/emoji-picker-element-data/pull/8