### PR TITLE
fix: use correct "red heart" in default favorites

### DIFF
--- a/src/picker/constants.js
+++ b/src/picker/constants.js
@@ -9,7 +9,7 @@ export const DEFAULT_NUM_COLUMNS = 8
 export const MOST_COMMONLY_USED_EMOJI = [
   '😊',
   '😒',
-  '♥️',
+  '❤️',
   '👍️',
   '😍',
   '😂',


### PR DESCRIPTION
Fixes #384 