### PR TITLE
test: add test to ensure that node is defined

### DIFF
--- a/src/picker/utils/calculateTextWidth.js
+++ b/src/picker/utils/calculateTextWidth.js
@@ -1,7 +1,13 @@
 // get the width of the text inside of a DOM node, via https://stackoverflow.com/a/59525891/680742
 export function calculateTextWidth (node) {
+  // skip running this in jest/vitest because we don't need to check for emoji support in that environment
   /* istanbul ignore else */
   if (import.meta.env.MODE === 'test') {
+    // sanity check to make sure the node is defined properly
+    /* istanbul ignore if */
+    if (!node) {
+      throw new Error('node should not be undefined/null')
+    }
     return 1
   } else {
     const range = document.createRange()


### PR DESCRIPTION
#418 makes me a bit nervous but I can't seem to find any case in the Vitest tests at least where the `node` would be undefined... this adds a check to prove it.