### PR TITLE
chore: remove focus-visible polyfill from local dev server

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Here is a full list of options:
 
 ### Focus outline
 
-For accessibility reasons, `emoji-picker-element` displays a prominent focus ring. If you want to hide the focus ring for non-keyboard users (e.g. mouse and touch only), then use the [focus-visible](https://github.com/WICG/focus-visible) polyfill, e.g.:
+For accessibility reasons, `emoji-picker-element` displays a prominent focus ring for keyboard users. This uses [`:focus-visible`](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible) under the hood. To properly support [browsers that do not support `:focus-visible`](https://caniuse.com/css-focus-visible), you can use the [focus-visible](https://github.com/WICG/focus-visible) polyfill, e.g.:
 
 ```js
 import 'focus-visible';

--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
     "fast-glob": "^3.3.2",
     "fetch-mock": "^9.11.0",
     "flat-color-icons": "^1.1.0",
-    "focus-visible": "^5.2.0",
     "get-folder-size": "^4.0.0",
     "husky": "^9.0.11",
     "jsdom": "^24.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,9 +80,6 @@ devDependencies:
   flat-color-icons:
     specifier: ^1.1.0
     version: 1.1.0
-  focus-visible:
-    specifier: ^5.2.0
-    version: 5.2.0
   get-folder-size:
     specifier: ^4.0.0
     version: 4.0.0
@@ -3413,10 +3410,6 @@ packages:
 
   /flatted@3.3.1:
     resolution: {integrity: sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==}
-    dev: true
-
-  /focus-visible@5.2.0:
-    resolution: {integrity: sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ==}
     dev: true
 
   /for-each@0.3.3:

--- a/test/adhoc/index.html
+++ b/test/adhoc/index.html
@@ -47,7 +47,6 @@
 </head>
 <body>
 <button class="delete">Delete database</button>
-<script src="/node_modules/focus-visible/dist/focus-visible.js"></script>
 <script type="module">
   import { Picker, Database } from '/index.js'
   (async () => {
@@ -89,7 +88,6 @@
     }
     const picker = new Picker(opts)
     picker.addEventListener('emoji-click', e => console.log(e))
-    applyFocusVisiblePolyfill(picker.shadowRoot)
     document.body.appendChild(picker)
   })()
 </script>


### PR DESCRIPTION
All browsers support this now, the polyfill can be de-emphasized.