### PR TITLE
chore: fix tachometer package swapping

### DIFF
--- a/bin/setupTachometerConfigs.js
+++ b/bin/setupTachometerConfigs.js
@@ -40,8 +40,7 @@ for (const benchmark of benchmarks) {
                   ref: 'master',
                   setupCommands: [
                     // we're comparing against historical branches, so support yarn as well as pnpm since we switched
-                    'if [ -f yarn.lock ]; then yarn --frozen-lockfile; else pnpm i --frozen-lockfile; fi',
-                    'PERF=1 npm run build:rollup'
+                    'if [ -f yarn.lock ]; then yarn --frozen-lockfile; else pnpm i --frozen-lockfile; fi'
                   ]
                 }
               }

--- a/bin/setupTachometerConfigs.js
+++ b/bin/setupTachometerConfigs.js
@@ -34,7 +34,7 @@ for (const benchmark of benchmarks) {
             packageVersions: {
               label: 'tip-of-tree',
               dependencies: {
-                'emoji-picker-element': {
+                '@nolanlawson/emoji-picker-element-for-tachometer': {
                   kind: 'git',
                   repo: 'https://github.com/nolanlawson/emoji-picker-element.git',
                   ref: 'master',

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
   },
   "homepage": "https://github.com/nolanlawson/emoji-picker-element#readme",
   "devDependencies": {
+    "@nolanlawson/emoji-picker-element-for-tachometer": "file:.",
     "@rollup/plugin-commonjs": "^26.0.1",
     "@rollup/plugin-inject": "^5.0.5",
     "@rollup/plugin-node-resolve": "^15.2.3",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,12 @@
     "url": "https://github.com/nolanlawson/emoji-picker-element/issues"
   },
   "homepage": "https://github.com/nolanlawson/emoji-picker-element#readme",
+  "//": {
+    "@nolanlawson/emoji-picker-element-for-tachometer": [
+      "Placeholder package for Tachometer to swap correctly, see https://github.com/nolanlawson/emoji-picker-element/pull/439/",
+      "Note the @nolanlawson scope to avoid any accidental dependency confusion vulnerability"
+    ]
+  },
   "devDependencies": {
     "@nolanlawson/emoji-picker-element-for-tachometer": "file:.",
     "@rollup/plugin-commonjs": "^26.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@nolanlawson/emoji-picker-element-for-tachometer':
+        specifier: file:.
+        version: 'emoji-picker-element@file:'
       '@rollup/plugin-commonjs':
         specifier: ^26.0.1
         version: 26.0.1(rollup@4.19.1)
@@ -1511,6 +1514,9 @@ packages:
 
   emoji-picker-element-data@1.6.1:
     resolution: {integrity: sha512-VYXjjqWYy12/uUA3q5X6Di0zROXp8TGwPiikXkhs97n3d3q3OaRV2sxGtUUColoSMPp5lfASZB9E4W+yN40qUg==}
+
+  'emoji-picker-element@file:':
+    resolution: {directory: '', type: directory}
 
   emoji-regex@10.3.0:
     resolution: {integrity: sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==}
@@ -5588,6 +5594,8 @@ snapshots:
   electron-to-chromium@1.4.715: {}
 
   emoji-picker-element-data@1.6.1: {}
+
+  'emoji-picker-element@file:': {}
 
   emoji-regex@10.3.0: {}
 

--- a/test/benchmark/benchmark.js
+++ b/test/benchmark/benchmark.js
@@ -1,11 +1,3 @@
-import { waitForPickerInitialLoad } from './utils.js'
-
-function instrumentPickerLoading () {
-  waitForPickerInitialLoad().then(entry => {
-    performance.measure('benchmark-total', { start: entry.startTime, duration: entry.duration })
-  })
-}
-
 function useFakeEtag () {
   // Fake an eTag on the headers for the emoji-picker data so that we actually reuse the cache.
   // Tachometer doesn't serve an eTag by default
@@ -22,10 +14,8 @@ const params = new URLSearchParams(window.location.search)
 const benchmark = params.get('benchmark') || 'first-load'
 
 if (benchmark === 'first-load') {
-  instrumentPickerLoading()
   await import('./first-load.benchmark.js')
 } else if (benchmark === 'second-load') {
-  instrumentPickerLoading()
   useFakeEtag()
   await import('./second-load.benchmark.js')
 } else if (benchmark === 'database-interactions') {

--- a/test/benchmark/change-tab.benchmark.js
+++ b/test/benchmark/change-tab.benchmark.js
@@ -1,10 +1,10 @@
 import { Picker } from '@nolanlawson/emoji-picker-element-for-tachometer'
-import { waitForElementWithId, postRaf, waitForPickerInitialLoad, dataSource } from './utils.js'
+import { waitForElementWithId, postRaf, dataSource } from './utils.js'
 
 const picker = new Picker({ dataSource })
 document.body.appendChild(picker)
 
-await waitForPickerInitialLoad()
+await waitForElementWithId(picker.shadowRoot, 'emo-🥰')
 await postRaf()
 const peopleTabButton = picker.shadowRoot.querySelector('[role="tab"][aria-label="People and body"]')
 

--- a/test/benchmark/change-tab.benchmark.js
+++ b/test/benchmark/change-tab.benchmark.js
@@ -1,4 +1,4 @@
-import Picker from '../../picker.js'
+import { Picker } from '@nolanlawson/emoji-picker-element-for-tachometer'
 import { waitForElementWithId, postRaf, waitForPickerInitialLoad, dataSource } from './utils.js'
 
 const picker = new Picker({ dataSource })

--- a/test/benchmark/database-interactions.benchmark.js
+++ b/test/benchmark/database-interactions.benchmark.js
@@ -1,4 +1,4 @@
-import Database from '../../database.js'
+import { Database } from '@nolanlawson/emoji-picker-element-for-tachometer'
 import { dataSource } from './utils.js'
 
 performance.mark('start-db-interactions')

--- a/test/benchmark/first-load.benchmark.js
+++ b/test/benchmark/first-load.benchmark.js
@@ -1,4 +1,9 @@
 import { Picker } from '@nolanlawson/emoji-picker-element-for-tachometer'
-import { dataSource } from './utils.js'
+import { dataSource, postRaf, waitForElementWithId } from './utils.js'
 
-document.body.appendChild(new Picker({ dataSource }))
+performance.mark('benchmark-start')
+const picker = new Picker({ dataSource })
+document.body.appendChild(picker)
+await waitForElementWithId(picker.shadowRoot, 'emo-🥰')
+await postRaf()
+performance.measure('benchmark-total', 'benchmark-start')

--- a/test/benchmark/first-load.benchmark.js
+++ b/test/benchmark/first-load.benchmark.js
@@ -1,4 +1,4 @@
-import Picker from '../../picker.js'
+import { Picker } from '@nolanlawson/emoji-picker-element-for-tachometer'
 import { dataSource } from './utils.js'
 
 document.body.appendChild(new Picker({ dataSource }))

--- a/test/benchmark/search.benchmark.js
+++ b/test/benchmark/search.benchmark.js
@@ -1,10 +1,10 @@
 import { Picker } from '@nolanlawson/emoji-picker-element-for-tachometer'
-import { waitForElementWithId, postRaf, waitForPickerInitialLoad, dataSource } from './utils.js'
+import { waitForElementWithId, postRaf, dataSource } from './utils.js'
 
 const picker = new Picker({ dataSource })
 document.body.appendChild(picker)
 
-await waitForPickerInitialLoad()
+await waitForElementWithId(picker.shadowRoot, 'emo-🥰')
 await postRaf()
 const searchBox = picker.shadowRoot.querySelector('[role="combobox"]')
 

--- a/test/benchmark/search.benchmark.js
+++ b/test/benchmark/search.benchmark.js
@@ -1,4 +1,4 @@
-import Picker from '../../picker.js'
+import { Picker } from '@nolanlawson/emoji-picker-element-for-tachometer'
 import { waitForElementWithId, postRaf, waitForPickerInitialLoad, dataSource } from './utils.js'
 
 const picker = new Picker({ dataSource })

--- a/test/benchmark/second-load.benchmark.js
+++ b/test/benchmark/second-load.benchmark.js
@@ -1,5 +1,5 @@
 import { Database } from '@nolanlawson/emoji-picker-element-for-tachometer'
-import { dataSource } from './utils.js'
+import { dataSource, postRaf, waitForElementWithId } from './utils.js'
 
 // populate IndexedDB so the Picker is just reading from the local store
 const db = new Database({ dataSource })
@@ -9,4 +9,9 @@ await db.close()
 // lazy-load the picker so that its logic to determine emoji support runs during the perf measure
 const { Picker } = await import('@nolanlawson/emoji-picker-element-for-tachometer')
 
-document.body.appendChild(new Picker({ dataSource }))
+performance.mark('benchmark-start')
+const picker = new Picker({ dataSource })
+document.body.appendChild(picker)
+await waitForElementWithId(picker.shadowRoot, 'emo-🥰')
+await postRaf()
+performance.measure('benchmark-total', 'benchmark-start')

--- a/test/benchmark/second-load.benchmark.js
+++ b/test/benchmark/second-load.benchmark.js
@@ -1,4 +1,4 @@
-import Database from '../../database.js'
+import { Database } from '@nolanlawson/emoji-picker-element-for-tachometer'
 import { dataSource } from './utils.js'
 
 // populate IndexedDB so the Picker is just reading from the local store
@@ -7,6 +7,6 @@ await db.ready()
 await db.close()
 
 // lazy-load the picker so that its logic to determine emoji support runs during the perf measure
-const { default: Picker } = await import('../../picker.js')
+const { Picker } = await import('@nolanlawson/emoji-picker-element-for-tachometer')
 
 document.body.appendChild(new Picker({ dataSource }))

--- a/test/benchmark/utils.js
+++ b/test/benchmark/utils.js
@@ -7,27 +7,4 @@ export const waitForElementWithId = async (root, id) => {
   }
 }
 
-export const waitForPickerInitialLoad = () => {
-  return new Promise((resolve, reject) => {
-    const observer = new PerformanceObserver(entries => {
-      for (const entry of entries.getEntries()) {
-        if (entry.name === 'initialLoad') {
-          // test to make sure the picker loaded with no errors
-          const hasErrors = document.querySelector('emoji-picker') && document.querySelector('emoji-picker')
-            .shadowRoot.querySelector('.message:not(.gone)')
-          if (hasErrors) {
-            const err = new Error('picker is showing an error message')
-            console.error(err)
-            reject(err)
-          } else {
-            resolve(entry)
-          }
-          observer.disconnect()
-        }
-      }
-    })
-    observer.observe({ entryTypes: ['measure'] })
-  })
-}
-
 export const dataSource = '/node_modules/emoji-picker-element-data/en/emojibase/data.json'


### PR DESCRIPTION
it looks like I've been using Tachometer incorrectly for some time, and wasn't actually comparing PRs against the master branch. :sweat_smile: 

Due to https://github.com/google/tachometer/issues/215 I need to make sure that any time we import the Picker/Database from a benchmark script, we do so from an npm package name that Tachometer can swap out. Luckily we can just create a dummy `file:.` dependency to do exactly this.

Without this PR, the local and "remote" versions of Tachometer are both the same – just the local code!