### PR TITLE
chore: run benchmarks in non-PERF mode

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -26,7 +26,6 @@ jobs:
         run: |
           # install the chromedriver corresponding to whatever version of chrome is installed
           pnpm i chromedriver@^$(google-chrome --version | awk '{print $3}' | cut -d. -f1)
-          PERF=1 pnpm build:rollup
           pnpm benchmark:runtime:setup
 
       # first-load

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:i18n-docs": "node ./bin/generateI18nDocs",
     "build:toc": "node ./bin/generateTOC",
     "build:i18n": "node ./bin/buildI18n",
-    "benchmark:runtime": "cross-env PERF=1 run-s build:rollup benchmark:runtime:setup benchmark:runtime:test",
+    "benchmark:runtime": "run-s build:rollup benchmark:runtime:setup benchmark:runtime:test",
     "benchmark:runtime:setup": "node ./bin/setupTachometerConfigs.js",
     "benchmark:runtime:test": "for config in ./test/benchmark/*.tachometer.json; do echo \"${config}\"; tach --config \"${config}\"; done",
     "benchmark:bundlesize": "run-s build:rollup benchmark:bundle benchmark:run-bundlesize",


### PR DESCRIPTION
Follow-up to #439 

Unfortunately, since I can't figure out how to get `PERF=1` mode running when Tachometer builds the remote branch, we should just disable it everywhere. It gives additional instrumentation, which may distort the benchmark since we're not technically comparing apples to apples. The downside is that it's harder to debug the benchmarks, but it's better to have accurate benchmarks than debuggable ones (for now).