### PR TITLE
perf: use `willReadFrequently`

### DIFF
--- a/src/picker/utils/testColorEmojiSupported.js
+++ b/src/picker/utils/testColorEmojiSupported.js
@@ -22,7 +22,11 @@ const getTextFeature = (text, color) => {
   const canvas = document.createElement('canvas')
   canvas.width = canvas.height = 1
 
-  const ctx = canvas.getContext('2d')
+  const ctx = canvas.getContext('2d', {
+    // Improves the performance of `getImageData()`
+    // https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/getContextAttributes#willreadfrequently
+    willReadFrequently: true
+  })
   ctx.textBaseline = 'top'
   ctx.font = `100px ${FONT_FAMILY}`
   ctx.fillStyle = color


### PR DESCRIPTION
This improves the perf of determining the emoji support level, although to see the difference you have to run Chrome in headful mode (interestingly).

```
second-load

┌─────────────┬───────────┐
│     Browser │ chrome    │
│             │ 127.0.0.0 │
├─────────────┼───────────┤
│ Sample size │ 100       │
└─────────────┴───────────┘

┌─────────────┬─────────────┬────────────┬─────────────────────┬───────────────────┬───────────────────┐
│ Benchmark   │ Version     │ Bytes      │            Avg time │    vs this-change │    vs tip-of-tree │
│             │             │            │                     │                   │       tip-of-tree │
├─────────────┼─────────────┼────────────┼─────────────────────┼───────────────────┼───────────────────┤
│ this-change │ <none>      │ 860.51 KiB │ 183.09ms - 187.15ms │                   │            faster │
│             │             │            │                     │          -        │          9% - 13% │
│             │             │            │                     │                   │ 17.95ms - 26.59ms │
├─────────────┼─────────────┼────────────┼─────────────────────┼───────────────────┼───────────────────┤
│ tip-of-tree │ tip-of-tree │ 860.47 KiB │ 203.58ms - 211.21ms │            slower │                   │
│             │             │            │                     │         10% - 14% │          -        │
│             │             │            │                     │ 17.95ms - 26.59ms │                   │
└─────────────┴─────────────┴────────────┴─────────────────────┴───────────────────┴───────────────────┘


```