### PR TITLE
perf: use `content-visibility` for custom emoji

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -102,3 +102,18 @@ jobs:
           path: test/benchmark/search.results.json
           pr-bench-name: this-change
           base-bench-name: tip-of-tree
+
+      # many-custom-emoji
+      - name: Benchmark many-custom-emoji
+        run: |
+          ./node_modules/.bin/tach \
+            --config ./test/benchmark/many-custom-emoji.tachometer.json \
+            --json-file ./test/benchmark/many-custom-emoji.results.json
+
+      - name: Report many-custom-emoji
+        uses: andrewiggins/tachometer-reporter-action@v2
+        with:
+          report-id: emoji-picker-element-many-custom-emoji
+          path: test/benchmark/many-custom-emoji.results.json
+          pr-bench-name: this-change
+          base-bench-name: tip-of-tree

--- a/src/picker/components/Picker/PickerTemplate.js
+++ b/src/picker/components/Picker/PickerTemplate.js
@@ -192,7 +192,7 @@ export function render (container, state, helpers, events, actions, refs, abortS
               The \`--expected-num-rows\` is also used in these calculations to contain the intrinsic height
             -->
           <div class="emoji-menu ${!state.searchMode && emojiWithCategory.category ? 'hide-offscreen' : ''}"
-               style=${`--expected-num-rows: ${Math.ceil(emojiWithCategory.emojis.length / state.numColumns)}`}
+               style=${`--num-rows: ${Math.ceil(emojiWithCategory.emojis.length / state.numColumns)}`}
                role="${state.searchMode ? 'listbox' : 'menu'}"
                aria-labelledby="menu-label-${i}"
                id=${state.searchMode ? 'search-results' : ''}

--- a/src/picker/components/Picker/PickerTemplate.js
+++ b/src/picker/components/Picker/PickerTemplate.js
@@ -191,7 +191,7 @@ export function render (container, state, helpers, events, actions, refs, abortS
               Improve performance in custom emoji by using \`content-visibility: auto\` on every category 
               The \`--expected-num-rows\` is also used in these calculations to contain the intrinsic height
             -->
-          <div class="emoji-menu ${!state.searchMode && emojiWithCategory.category ? 'lazy' : ''}"
+          <div class="emoji-menu ${!state.searchMode && emojiWithCategory.category ? 'hide-offscreen' : ''}"
                style=${`--expected-num-rows: ${Math.ceil(emojiWithCategory.emojis.length / state.numColumns)}`}
                role="${state.searchMode ? 'listbox' : 'menu'}"
                aria-labelledby="menu-label-${i}"

--- a/src/picker/components/Picker/PickerTemplate.js
+++ b/src/picker/components/Picker/PickerTemplate.js
@@ -187,10 +187,16 @@ export function render (container, state, helpers, events, actions, refs, abortS
                     )
                 }
           </div>
-          <div class="emoji-menu"
+            <!-- 
+              Improve performance in custom emoji by using \`content-visibility: auto\` on every category 
+              The \`--expected-num-rows\` is also used in these calculations to contain the intrinsic height
+            -->
+          <div class="emoji-menu ${!state.searchMode && emojiWithCategory.category ? 'lazy' : ''}"
+               style=${`--expected-num-rows: ${Math.ceil(emojiWithCategory.emojis.length / state.numColumns)}`}
                role="${state.searchMode ? 'listbox' : 'menu'}"
                aria-labelledby="menu-label-${i}"
-               id=${state.searchMode ? 'search-results' : ''}>
+               id=${state.searchMode ? 'search-results' : ''}
+          >
             ${
               emojiList(emojiWithCategory.emojis, state.searchMode, /* prefix */ 'emo')
             }

--- a/src/picker/components/Picker/PickerTemplate.js
+++ b/src/picker/components/Picker/PickerTemplate.js
@@ -189,7 +189,7 @@ export function render (container, state, helpers, events, actions, refs, abortS
           </div>
             <!-- 
               Improve performance in custom emoji by using \`content-visibility: auto\` on every category 
-              The \`--expected-num-rows\` is also used in these calculations to contain the intrinsic height
+              The \`--num-rows\` is also used in these calculations to contain the intrinsic height
             -->
           <div class="emoji-menu ${!state.searchMode && emojiWithCategory.category ? 'hide-offscreen' : ''}"
                style=${`--num-rows: ${Math.ceil(emojiWithCategory.emojis.length / state.numColumns)}`}

--- a/src/picker/styles/picker.scss
+++ b/src/picker/styles/picker.scss
@@ -77,7 +77,7 @@ $skintoneZIndex3: 3;
       // width
       calc(var(--num-columns) * var(--total-emoji-size))
       // height
-      calc(var(--expected-num-rows) * var(--total-emoji-size));
+      calc(var(--num-rows) * var(--total-emoji-size));
   }
 }
 

--- a/src/picker/styles/picker.scss
+++ b/src/picker/styles/picker.scss
@@ -69,6 +69,16 @@ $skintoneZIndex3: 3;
   justify-content: space-around;
   align-items: flex-start;
   width: 100%;
+
+  // Improve performance in custom emoji by using `content-visibility: auto` on every category
+  &.lazy {
+    content-visibility: auto;
+    contain-intrinsic-size:
+      // width
+      calc(var(--num-columns) * var(--total-emoji-size))
+      // height
+      calc(var(--expected-num-rows) * var(--total-emoji-size));
+  }
 }
 
 .category {
@@ -104,6 +114,7 @@ button.emoji,
   &.active {
     background: var(--button-active-background);
   }
+
 }
 
 .custom-emoji {

--- a/src/picker/styles/picker.scss
+++ b/src/picker/styles/picker.scss
@@ -114,7 +114,6 @@ button.emoji,
   &.active {
     background: var(--button-active-background);
   }
-
 }
 
 .custom-emoji {

--- a/src/picker/styles/picker.scss
+++ b/src/picker/styles/picker.scss
@@ -71,7 +71,7 @@ $skintoneZIndex3: 3;
   width: 100%;
 
   // Improve performance in custom emoji by using `content-visibility: auto` on every category
-  &.lazy {
+  &.hide-offscreen {
     content-visibility: auto;
     contain-intrinsic-size:
       // width

--- a/test/benchmark/benchmark.js
+++ b/test/benchmark/benchmark.js
@@ -24,4 +24,6 @@ if (benchmark === 'first-load') {
   await import('./change-tab.benchmark.js')
 } else if (benchmark === 'search') {
   await import('./search.benchmark.js')
+} else if (benchmark === 'many-custom-emoji') {
+  await import('./many-custom-emoji.benchmark.js')
 }

--- a/test/benchmark/many-custom-emoji.benchmark.js
+++ b/test/benchmark/many-custom-emoji.benchmark.js
@@ -12,11 +12,14 @@ const buildCustomEmoji = () => {
       const image = CUSTOM_EMOJI_IMAGES[(i + j) % CUSTOM_EMOJI_IMAGES.length]
       return {
         category: `category-${i}`,
-        shortcode: `category-${i}-emoji-${j}`,
-        name: `category-${i}-emoji-${j}`,
-        tags: [
-                    `category-${i}-emoji-${j}`
+        shortcodes: [
+          image,
+            `x${image}-y${image}-z${image}`,
+            `a${image}-b${image}-c${image}`,
+            `x${image}x-y${image}y-z${image}z`,
+            `a${image}a-b${image}b-c${image}c`
         ],
+        name: `category-${i}-emoji-${j}`,
         url: `/docs/custom/${image}.svg`
       }
     })

--- a/test/benchmark/many-custom-emoji.benchmark.js
+++ b/test/benchmark/many-custom-emoji.benchmark.js
@@ -1,0 +1,42 @@
+import { Picker } from '@nolanlawson/emoji-picker-element-for-tachometer'
+import { waitForElementWithId, postRaf, dataSource } from './utils.js'
+
+const CUSTOM_EMOJI_IMAGES = ['about', 'accept_database', 'add_column', 'add_database', 'add_image', 'add_row', 'address_book', 'advance', 'alarm_clock', 'alphabetical_sorting_az', 'alphabetical_sorting_za', 'answers', 'approval', 'approve', 'area_chart', 'assistant', 'audio_file', 'automatic', 'automotive', 'bad_decision', 'bar_chart', 'bearish', 'binoculars', 'biohazard', 'biomass', 'biotech', 'bookmark', 'briefcase', 'broken_link', 'bullish', 'business', 'business_contact', 'businessman', 'businesswoman', 'butting_in', 'calculator', 'calendar', 'call_transfer', 'callback', 'camcorder', 'camcorder_pro', 'camera', 'camera_addon', 'camera_identification', 'cancel', 'candle_sticks', 'capacitor', 'cell_phone', 'charge_battery', 'checkmark', 'circuit', 'clapperboard', 'clear_filters', 'clock', 'close_up_mode', 'cloth', 'collaboration', 'collapse', 'collect', 'combo_chart', 'command_line', 'comments', 'compact_camera', 'conference_call', 'contacts', 'copyleft', 'copyright', 'crystal_oscillator', 'currency_exchange', 'cursor', 'customer_support', 'dam', 'data_backup', 'data_configuration', 'data_encryption', 'data_protection', 'data_recovery', 'data_sheet', 'database', 'debt', 'decision', 'delete_column', 'delete_database', 'delete_row', 'department', 'deployment', 'diploma_1', 'diploma_2', 'disapprove', 'disclaimer', 'dislike', 'display', 'do_not_inhale', 'do_not_insert', 'do_not_mix', 'document', 'donate', 'doughnut_chart', 'down', 'down_left', 'down_right', 'download', 'edit_image', 'electrical_sensor', 'electrical_threshold', 'electricity', 'electro_devices', 'electronics', 'empty_battery', 'empty_filter', 'empty_trash', 'end_call', 'engineering', 'expand', 'expired', 'export', 'external', 'factory', 'factory_breakdown', 'faq', 'feed_in', 'feedback', 'file', 'filing_cabinet', 'filled_filter', 'film', 'film_reel', 'fine_print', 'flash_auto', 'flash_off', 'flash_on', 'flow_chart', 'folder', 'frame', 'full_battery', 'full_trash', 'gallery', 'genealogy', 'generic_sorting_asc', 'generic_sorting_desc', 'globe', 'good_decision', 'graduation_cap', 'grid', 'headset', 'heat_map', 'high_battery', 'high_priority', 'home', 'idea', 'image_file', 'import', 'in_transit', 'info', 'inspection', 'integrated_webcam', 'internal', 'invite', 'key', 'landscape', 'leave', 'left', 'left_down', 'left_down2', 'left_up', 'left_up2', 'library', 'light_at_the_end_of_tunnel', 'like', 'like_placeholder', 'line_chart', 'link', 'list', 'lock', 'lock_landscape', 'lock_portrait', 'low_battery', 'low_priority', 'make_decision', 'manager', 'medium_priority', 'menu', 'middle_battery', 'mind_map', 'minus', 'missed_call', 'mms', 'money_transfer', 'multiple_cameras', 'multiple_devices', 'multiple_inputs', 'multiple_smartphones', 'music', 'negative_dynamic', 'neutral_decision', 'neutral_trading', 'news', 'next', 'night_landscape', 'night_portrait', 'no_idea', 'no_video', 'numerical_sorting_12', 'numerical_sorting_21', 'ok', 'old_time_camera', 'online_support', 'opened_folder', 'org_unit', 'organization', 'overtime', 'package', 'paid', 'panorama', 'parallel_tasks', 'phone', 'photo_reel', 'picture', 'pie_chart', 'planner', 'plus', 'podium_with_audience', 'podium_with_speaker', 'podium_without_speaker', 'portrait_mode', 'positive_dynamic', 'previous', 'print', 'privacy', 'process', 'puzzle', 'questions', 'radar_plot', 'rating', 'ratings', 'reading', 'reading_ebook', 'redo', 'refresh', 'registered_trademark', 'remove_image', 'reuse', 'right', 'right_down', 'right_down2', 'right_up', 'right_up2', 'rotate_camera', 'rotate_to_landscape', 'rotate_to_portrait', 'ruler', 'rules', 'safe', 'sales_performance', 'scatter_plot', 'search', 'self_service_kiosk', 'selfie', 'serial_tasks', 'service_mark', 'services', 'settings', 'share', 'shipped', 'shop', 'signature', 'sim_card', 'sim_card_chip', 'slr_back_side', 'smartphone_tablet', 'sms', 'sound_recording_copyright', 'speaker', 'sports_mode', 'stack_of_photos', 'start', 'statistics', 'support', 'survey', 'switch_camera', 'synchronize', 'template', 'timeline', 'todo_list', 'touchscreen_smartphone', 'trademark', 'tree_structure', 'two_smartphones', 'undo', 'unlock', 'up', 'up_left', 'up_right', 'upload', 'video_call', 'video_file', 'video_projector', 'view_details', 'vip', 'voice_presentation', 'voicemail', 'webcam', 'workflow']
+
+const NUM_CATEGORIES = 100
+const NUM_EMOJI_PER_CATEGORY = 20
+
+const buildCustomEmoji = () => {
+  return Array.from({ length: NUM_CATEGORIES }, (_, i) => {
+    return Array.from({ length: NUM_EMOJI_PER_CATEGORY }, (_, j) => {
+      const image = CUSTOM_EMOJI_IMAGES[(i + j) % CUSTOM_EMOJI_IMAGES.length]
+      return {
+        category: `category-${i}`,
+        shortcode: `category-${i}-emoji-${j}`,
+        name: `category-${i}-emoji-${j}`,
+        tags: [
+                    `category-${i}-emoji-${j}`
+        ],
+        url: `/docs/custom/${image}.svg`
+      }
+    })
+  }).flat()
+}
+
+const customEmoji = buildCustomEmoji()
+
+// preload the images to avoid measuring network time
+await Promise.all(CUSTOM_EMOJI_IMAGES.map(_ => fetch(`/docs/custom/${_}.svg`)))
+
+performance.mark('benchmark-start')
+
+const picker = new Picker({
+  dataSource,
+  customEmoji
+})
+document.body.appendChild(picker)
+
+await waitForElementWithId(picker.shadowRoot, 'emo-category-0-emoji-0')
+await postRaf()
+
+performance.measure('benchmark-total', 'benchmark-start')


### PR DESCRIPTION
Rather than using list virtualization (which has accessibility and complexity issues), we can use [`content-visibility`](https://web.dev/articles/content-visibility#skipping_rendering_work_with_content-visibility) to hide offscreen categories of custom emoji. This should significantly reduce layout costs, at least in browsers that support `content-visibility` (Safari has it in Tech Preview only).

Helps with #444 a lot, although there is probably more work we can do.