### PR TITLE
perf: avoid recalculating custom emoji index

### DIFF
--- a/src/picker/components/Picker/Picker.js
+++ b/src/picker/components/Picker/Picker.js
@@ -323,8 +323,13 @@ export function createRoot (shadowRoot, props) {
   function updateCustomEmoji () {
     // Certain effects have an implicit dependency on customEmoji since it affects the database
     // Getting it here on the state ensures this effect re-runs when customEmoji change.
-    // Setting it on the database is pointless but prevents this code from being removed by a minifier.
-    state.database.customEmoji = state.customEmoji || EMPTY_ARRAY
+    const { customEmoji, database } = state
+    const databaseCustomEmoji = customEmoji || EMPTY_ARRAY
+    if (database.customEmoji !== databaseCustomEmoji) {
+      // Avoid setting this if the customEmoji have _not_ changed, because the setter triggers a re-computation of the
+      // `customEmojiIndex`. Note we don't bother with deep object changes.
+      database.customEmoji = databaseCustomEmoji
+    }
   }
 
   createEffect(() => {


### PR DESCRIPTION
This won't show up in the benchmarks, but we do an extra recalculation of the custom emoji search index that we don't need to.