### PR TITLE
perf: remove `<img>`'s `src` when offscreen

### DIFF
--- a/bin/bundlesize.js
+++ b/bin/bundlesize.js
@@ -5,7 +5,7 @@ import { promisify } from 'node:util'
 import prettyBytes from 'pretty-bytes'
 import fs from 'node:fs/promises'
 
-const MAX_SIZE_MIN = '37 kB'
+const MAX_SIZE_MIN = '38 kB'
 const MAX_SIZE_MINGZ = '13 kB'
 
 const FILENAME = './bundle.js'

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
       "btoa",
       "crypto",
       "customElements",
+      "CSS",
       "CustomEvent",
       "Event",
       "fetch",

--- a/src/picker/components/Picker/Picker.js
+++ b/src/picker/components/Picker/Picker.js
@@ -183,7 +183,7 @@ export function createRoot (shadowRoot, props) {
   }
   const actions = {
     calculateEmojiGridStyle,
-    updateOnIntersectionChange
+    updateOnContentVisibilityChange
   }
 
   let firstRender = true
@@ -382,7 +382,7 @@ export function createRoot (shadowRoot, props) {
 
   // Re-run whenever the custom emoji in a category are shown/hidden. This is an optimization to prevent the browser
   // from doing extra work for offscreen `<img>`s with `src`s, which seems to occur even with `loading="lazy"`.
-  function updateOnIntersectionChange (node) {
+  function updateOnContentVisibilityChange (node) {
     contentVisibilityAction(node, abortSignal, ({ skipped }) => {
       node.classList.toggle('onscreen', !skipped)
       /* istanbul ignore else */

--- a/src/picker/components/Picker/Picker.js
+++ b/src/picker/components/Picker/Picker.js
@@ -23,6 +23,7 @@ import { resetScrollTopIfPossible } from '../../utils/resetScrollTopIfPossible.j
 import { render } from './PickerTemplate.js'
 import { createState } from './reactivity.js'
 import { arraysAreEqualByFunction } from '../../utils/arraysAreEqualByFunction.js'
+import { contentVisibilityAction } from '../../utils/contentVisibilityAction.js'
 
 // constants
 const EMPTY_ARRAY = []
@@ -34,6 +35,7 @@ export function createRoot (shadowRoot, props) {
   const abortController = new AbortController()
   const abortSignal = abortController.signal
   const { state, createEffect } = createState(abortSignal)
+  const actionContext = Object.create(null)
 
   // initial state
   assign(state, {
@@ -180,12 +182,13 @@ export function createRoot (shadowRoot, props) {
     onSearchInput
   }
   const actions = {
-    calculateEmojiGridStyle
+    calculateEmojiGridStyle,
+    updateOnIntersectionChange
   }
 
   let firstRender = true
   createEffect(() => {
-    render(shadowRoot, state, helpers, events, actions, refs, abortSignal, firstRender)
+    render(shadowRoot, state, helpers, events, actions, refs, abortSignal, actionContext, firstRender)
     firstRender = false
   })
 
@@ -373,6 +376,20 @@ export function createRoot (shadowRoot, props) {
         // write to state variables
         state.numColumns = newNumColumns
         state.isRtl = newIsRtl
+      }
+    })
+  }
+
+  // Re-run whenever the custom emoji in a category are shown/hidden. This is an optimization to prevent the browser
+  // from doing extra work for offscreen `<img>`s with `src`s, which seems to occur even with `loading="lazy"`.
+  function updateOnIntersectionChange (node) {
+    contentVisibilityAction(node, abortSignal, ({ skipped }) => {
+      node.classList.toggle('onscreen', !skipped)
+      /* istanbul ignore else */
+      if (!skipped) {
+        for (const img of node.querySelectorAll('img')) {
+          img.setAttribute('src', img.getAttribute('data-src'))
+        }
       }
     })
   }

--- a/src/picker/components/Picker/PickerTemplate.js
+++ b/src/picker/components/Picker/PickerTemplate.js
@@ -4,7 +4,7 @@ export function render (container, state, helpers, events, actions, refs, abortS
   const { labelWithSkin, titleForEmoji, unicodeWithSkin } = helpers
   const { html, map } = createFramework(state)
 
-  function emojiList (emojis, searchMode, prefix) {
+  function emojiList (emojis, searchMode, prefix, hideOffscreen) {
     return map(emojis, (emoji, i) => {
       return html`
       <button role="${searchMode ? 'option' : 'menuitem'}"
@@ -24,6 +24,7 @@ export function render (container, state, helpers, events, actions, refs, abortS
                       alt="" 
                       loading="lazy"
                       data-src="${emoji.url}"
+                      src=${hideOffscreen ? '' : emoji.url}
                 />`
       }
       </button>
@@ -207,7 +208,7 @@ export function render (container, state, helpers, events, actions, refs, abortS
                id=${state.searchMode ? 'search-results' : ''}
           >
             ${
-              emojiList(emojiWithCategory.emojis, state.searchMode, /* prefix */ 'emo')
+              emojiList(emojiWithCategory.emojis, state.searchMode, /* prefix */ 'emo', hideOffscreen)
             }
           </div>
         </div>
@@ -222,7 +223,8 @@ export function render (container, state, helpers, events, actions, refs, abortS
              aria-label="${state.i18n.favoritesLabel}"
              data-on-click="onEmojiClick">
           ${
-            emojiList(state.currentFavorites, /* searchMode */ false, /* prefix */ 'fav')
+            // favorites bar does not participate in the hideOffscreen optimization; it's always visible
+            emojiList(state.currentFavorites, /* searchMode */ false, /* prefix */ 'fav', /* hideOffscreen */ false)
           }
         </div>
         <!-- This serves as a baseline emoji for measuring against and determining emoji support -->

--- a/src/picker/components/Picker/PickerTemplate.js
+++ b/src/picker/components/Picker/PickerTemplate.js
@@ -201,7 +201,7 @@ export function render (container, state, helpers, events, actions, refs, abortS
           </div>
           <div class="emoji-menu ${hideOffscreen ? 'hide-offscreen' : ''}"
                style=${`--num-rows: ${Math.ceil(emojiWithCategory.emojis.length / state.numColumns)}`}
-               data-action="${hideOffscreen ? 'updateOnIntersectionChange' : ''}"
+               data-action="${hideOffscreen ? 'updateOnContentVisibilityChange' : ''}"
                role="${state.searchMode ? 'listbox' : 'menu'}"
                aria-labelledby="menu-label-${i}"
                id=${state.searchMode ? 'search-results' : ''}

--- a/src/picker/styles/picker.scss
+++ b/src/picker/styles/picker.scss
@@ -78,6 +78,17 @@ $skintoneZIndex3: 3;
       calc(var(--num-columns) * var(--total-emoji-size))
       // height
       calc(var(--num-rows) * var(--total-emoji-size));
+
+    // Optimization - when images for custom emoji are offscreen, set `visibility:visible` so that we don't see a flash
+    // of broken images while we change the `data-src` to a `src` when the `content-visibility` auto state changes.
+    // Note that a11y-wise, setting `hidden` here is fine because the `<img>`s are already `alt=''` meaning
+    // they are marked as purely decorative.
+    .custom-emoji {
+      visibility: hidden;
+    }
+    &.onscreen .custom-emoji {
+      visibility: visible;
+    }
   }
 }
 

--- a/src/picker/utils/contentVisibilityAction.js
+++ b/src/picker/utils/contentVisibilityAction.js
@@ -1,0 +1,13 @@
+/* istanbul ignore next */
+const SUPPORTS_CONTENT_VISIBILITY = import.meta.env.MODE !== 'test' && CSS.supports('content-visibility', 'auto')
+
+export function contentVisibilityAction (node, signal, listener) {
+  /* istanbul ignore if */
+  if (SUPPORTS_CONTENT_VISIBILITY) {
+    node.addEventListener('contentvisibilityautostatechange', listener, { signal })
+  } else {
+    // If content visibility is unsupported, then just treat every element as always visible.
+    // This browser will just not get the optimization
+    listener({ skipped: false })
+  }
+}


### PR DESCRIPTION
This is an additional optimization on top of #445 in order to address #444.

It turns out that browsers seem to do some extra work when a `src` is set on an `<img>`, even if that image is offscreen, even if it's marked `<img loading=lazy>`, and _even_ if it's hidden with `content-visibility: auto`. To fix that, you can simply use the old `data-src` trick and set the `src` only when the `<img>` is visible.

To detect visibility, we can use the `contentvisibilityautostatechange` event (kind of like an `IntersectionObserver` but a bit simpler).

Oddly this event only seems to fire on the element itself and not bubble in Firefox only, but we can just set the event listener on the element itself to fix that.

Improvement in Chrome: 13-19%

```
┌─────────────┬─────────────────┐
│     Browser │ chrome-headless │
│             │ 128.0.0.0       │
├─────────────┼─────────────────┤
│ Sample size │ 300             │
└─────────────┴─────────────────┘

┌─────────────┬─────────────┬─────────────┬─────────────────────┬───────────────────┬───────────────────┐
│ Benchmark   │ Version     │ Bytes       │            Avg time │    vs this-change │    vs tip-of-tree │
│             │             │             │                     │                   │       tip-of-tree │
├─────────────┼─────────────┼─────────────┼─────────────────────┼───────────────────┼───────────────────┤
│ this-change │ <none>      │ 1029.47 KiB │ 155.77ms - 165.62ms │                   │            faster │
│             │             │             │                     │          -        │         13% - 19% │
│             │             │             │                     │                   │ 24.88ms - 37.22ms │
├─────────────┼─────────────┼─────────────┼─────────────────────┼───────────────────┼───────────────────┤
│ tip-of-tree │ tip-of-tree │ 1027.26 KiB │ 188.03ms - 195.47ms │            slower │                   │
│             │             │             │                     │         15% - 24% │          -        │
│             │             │             │                     │ 24.88ms - 37.22ms │                   │
└─────────────┴─────────────┴─────────────┴─────────────────────┴───────────────────┴───────────────────┘

```

Improvement in Firefox: 35-37%

```
┌─────────────┬──────────────────┐
│     Browser │ firefox-headless │
│             │ 130.0            │
├─────────────┼──────────────────┤
│ Sample size │ 200              │
└─────────────┴──────────────────┘

┌─────────────┬─────────────┬─────────────┬─────────────────────┬─────────────────────┬─────────────────────┐
│ Benchmark   │ Version     │ Bytes       │            Avg time │      vs this-change │      vs tip-of-tree │
│             │             │             │                     │                     │         tip-of-tree │
├─────────────┼─────────────┼─────────────┼─────────────────────┼─────────────────────┼─────────────────────┤
│ this-change │ <none>      │ 1020.95 KiB │ 240.02ms - 245.81ms │                     │              faster │
│             │             │             │                     │            -        │           35% - 37% │
│             │             │             │                     │                     │ 131.03ms - 139.76ms │
├─────────────┼─────────────┼─────────────┼─────────────────────┼─────────────────────┼─────────────────────┤
│ tip-of-tree │ tip-of-tree │ 1071.07 KiB │ 375.04ms - 381.58ms │              slower │                     │
│             │             │             │                     │           53% - 58% │            -        │
│             │             │             │                     │ 131.03ms - 139.76ms │                     │
└─────────────┴─────────────┴─────────────┴─────────────────────┴─────────────────────┴─────────────────────┘

```