### PR TITLE
perf: use `background-image` instead of `<img>`

### DIFF
--- a/bin/bundlesize.js
+++ b/bin/bundlesize.js
@@ -5,7 +5,7 @@ import { promisify } from 'node:util'
 import prettyBytes from 'pretty-bytes'
 import fs from 'node:fs/promises'
 
-const MAX_SIZE_MIN = '37 kB'
+const MAX_SIZE_MIN = '38 kB'
 const MAX_SIZE_MINGZ = '13 kB'
 
 const FILENAME = './bundle.js'

--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
       "Element",
       "indexedDB",
       "IDBKeyRange",
+      "IntersectionObserver",
       "Headers",
       "HTMLElement",
       "matchMedia",

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
       "btoa",
       "crypto",
       "customElements",
+      "CSS",
       "CustomEvent",
       "Event",
       "fetch",

--- a/src/picker/components/Picker/Picker.js
+++ b/src/picker/components/Picker/Picker.js
@@ -383,7 +383,7 @@ export function createRoot (shadowRoot, props) {
   // Re-run whenever the custom emoji in a category are shown/hidden. This is an optimization that simulates
   // what we'd get from `<img loading=lazy>` but without rendering an `<img>`.
   function updateOnContentVisibilityChange (node) {
-    contentVisibilityAction(node, abortSignal, ({ skipped }) => {
+    contentVisibilityAction(node, ({ skipped }) => {
       node.classList.toggle('onscreen', !skipped)
     })
   }

--- a/src/picker/components/Picker/Picker.js
+++ b/src/picker/components/Picker/Picker.js
@@ -383,8 +383,10 @@ export function createRoot (shadowRoot, props) {
   // Re-run whenever the custom emoji in a category are shown/hidden. This is an optimization that simulates
   // what we'd get from `<img loading=lazy>` but without rendering an `<img>`.
   function updateOnContentVisibilityChange (node) {
-    contentVisibilityAction(node, ({ skipped }) => {
-      node.classList.toggle('onscreen', !skipped)
+    contentVisibilityAction(node, abortSignal, (entries) => {
+      for (const { target, isIntersecting } of entries) {
+        target.classList.toggle('onscreen', isIntersecting)
+      }
     })
   }
 

--- a/src/picker/components/Picker/Picker.js
+++ b/src/picker/components/Picker/Picker.js
@@ -35,7 +35,7 @@ export function createRoot (shadowRoot, props) {
   const abortController = new AbortController()
   const abortSignal = abortController.signal
   const { state, createEffect } = createState(abortSignal)
-  const actionContext = Object.create(null)
+  const actionContext = new Map()
 
   // initial state
   assign(state, {

--- a/src/picker/components/Picker/Picker.js
+++ b/src/picker/components/Picker/Picker.js
@@ -23,7 +23,7 @@ import { resetScrollTopIfPossible } from '../../utils/resetScrollTopIfPossible.j
 import { render } from './PickerTemplate.js'
 import { createState } from './reactivity.js'
 import { arraysAreEqualByFunction } from '../../utils/arraysAreEqualByFunction.js'
-import { contentVisibilityAction } from '../../utils/contentVisibilityAction.js'
+import { intersectionObserverAction } from '../../utils/intersectionObserverAction.js'
 
 // constants
 const EMPTY_ARRAY = []
@@ -183,7 +183,7 @@ export function createRoot (shadowRoot, props) {
   }
   const actions = {
     calculateEmojiGridStyle,
-    updateOnContentVisibilityChange
+    updateOnIntersection
   }
 
   let firstRender = true
@@ -382,8 +382,8 @@ export function createRoot (shadowRoot, props) {
 
   // Re-run whenever the custom emoji in a category are shown/hidden. This is an optimization that simulates
   // what we'd get from `<img loading=lazy>` but without rendering an `<img>`.
-  function updateOnContentVisibilityChange (node) {
-    contentVisibilityAction(node, abortSignal, (entries) => {
+  function updateOnIntersection (node) {
+    intersectionObserverAction(node, abortSignal, (entries) => {
       for (const { target, isIntersecting } of entries) {
         target.classList.toggle('onscreen', isIntersecting)
       }

--- a/src/picker/components/Picker/PickerTemplate.js
+++ b/src/picker/components/Picker/PickerTemplate.js
@@ -200,7 +200,7 @@ export function render (container, state, helpers, events, actions, refs, abortS
             -->
           <div class="emoji-menu hide-offscreen"
                style=${`--num-rows: ${Math.ceil(emojiWithCategory.emojis.length / state.numColumns)}`}
-               data-action="updateOnContentVisibilityChange"
+               data-action="updateOnIntersection"
                role="${state.searchMode ? 'listbox' : 'menu'}"
                aria-labelledby="menu-label-${i}"
                id=${state.searchMode ? 'search-results' : ''}

--- a/src/picker/components/Picker/PickerTemplate.js
+++ b/src/picker/components/Picker/PickerTemplate.js
@@ -169,9 +169,6 @@ export function render (container, state, helpers, events, actions, refs, abortS
           <div data-action="calculateEmojiGridStyle">
             ${
               map(state.currentEmojisWithCategories, (emojiWithCategory, i) => {
-                  // Improve performance in custom emoji by using `content-visibility: auto` on every category
-                  // The `--num-rows` is used in these calculations to contain the intrinsic height
-                const hideOffscreen = !state.searchMode && state.currentGroup.id === -1 // -1 means custom emoji
                 return html`
         <!-- wrapper div so there's one top level element for this loop -->
         <div>
@@ -197,9 +194,13 @@ export function render (container, state, helpers, events, actions, refs, abortS
                     )
                 }
           </div>
-          <div class="emoji-menu ${hideOffscreen ? 'hide-offscreen' : ''}"
+            <!--
+              Improve performance in custom emoji by using \`content-visibility: auto\` on every category
+              The \`--num-rows\` is used in these calculations to contain the intrinsic height
+            -->
+          <div class="emoji-menu hide-offscreen"
                style=${`--num-rows: ${Math.ceil(emojiWithCategory.emojis.length / state.numColumns)}`}
-               data-action="${hideOffscreen ? 'updateOnContentVisibilityChange' : ''}"
+               data-action="updateOnContentVisibilityChange"
                role="${state.searchMode ? 'listbox' : 'menu'}"
                aria-labelledby="menu-label-${i}"
                id=${state.searchMode ? 'search-results' : ''}
@@ -265,9 +266,6 @@ export function render (container, state, helpers, events, actions, refs, abortS
 
   // set up actions
   forElementWithAttribute('data-action', (element, action) => {
-    if (!action) {
-      return // `data-action` may be set to the empty string, meaning don't do anything
-    }
     let boundActions = actionContext[action]
     if (!boundActions) {
       boundActions = actionContext[action] = new WeakSet()

--- a/src/picker/components/Picker/PickerTemplate.js
+++ b/src/picker/components/Picker/PickerTemplate.js
@@ -1,6 +1,6 @@
 import { createFramework } from './framework.js'
 
-export function render (container, state, helpers, events, actions, refs, abortSignal, firstRender) {
+export function render (container, state, helpers, events, actions, refs, abortSignal, actionContext, firstRender) {
   const { labelWithSkin, titleForEmoji, unicodeWithSkin } = helpers
   const { html, map } = createFramework(state)
 
@@ -11,12 +11,18 @@ export function render (container, state, helpers, events, actions, refs, abortS
               aria-selected="${state.searchMode ? i === state.activeSearchItem : ''}"
               aria-label="${labelWithSkin(emoji, state.currentSkinTone)}"
               title="${titleForEmoji(emoji)}"
-              class="emoji ${searchMode && i === state.activeSearchItem ? 'active' : ''}"
-              id=${`${prefix}-${emoji.id}`}>
+              class="${
+                'emoji' +
+                (searchMode && i === state.activeSearchItem ? ' active' : '') +
+                (emoji.unicode ? '' : ' custom-emoji')
+              }"
+              id=${`${prefix}-${emoji.id}`}
+              style="${`--custom-emoji-background: url(${JSON.stringify(emoji.url)})`}"
+      >
         ${
         emoji.unicode
           ? unicodeWithSkin(emoji, state.currentSkinTone)
-          : html`<img class="custom-emoji" src="${emoji.url}" alt="" loading="lazy"/>`
+          : ''
       }
       </button>
     `
@@ -152,7 +158,8 @@ export function render (container, state, helpers, events, actions, refs, abortS
         <!--The tabindex=0 is so people can scroll up and down with the keyboard. The element has a role and a label, so I
         feel it's appropriate to have the tabindex.
         This on:click is a delegated click listener -->
-        <div data-ref="tabpanelElement" class="tabpanel ${(!state.databaseLoaded || state.message) ? 'gone' : ''}"
+        <div data-ref="tabpanelElement" 
+             class="tabpanel ${(!state.databaseLoaded || state.message) ? 'gone' : ''}"
              role="${state.searchMode ? 'region' : 'tabpanel'}"
              aria-label="${state.searchMode ? state.i18n.searchResultsLabel : state.i18n.categories[state.currentGroup.name]}"
              id="${state.searchMode ? '' : `tab-${state.currentGroup.id}`}"
@@ -162,6 +169,9 @@ export function render (container, state, helpers, events, actions, refs, abortS
           <div data-action="calculateEmojiGridStyle">
             ${
               map(state.currentEmojisWithCategories, (emojiWithCategory, i) => {
+                  // Improve performance in custom emoji by using `content-visibility: auto` on every category
+                  // The `--num-rows` is used in these calculations to contain the intrinsic height
+                const hideOffscreen = !state.searchMode && state.currentGroup.id === -1 // -1 means custom emoji
                 return html`
         <!-- wrapper div so there's one top level element for this loop -->
         <div>
@@ -187,12 +197,9 @@ export function render (container, state, helpers, events, actions, refs, abortS
                     )
                 }
           </div>
-            <!-- 
-              Improve performance in custom emoji by using \`content-visibility: auto\` on every category 
-              The \`--num-rows\` is also used in these calculations to contain the intrinsic height
-            -->
-          <div class="emoji-menu ${!state.searchMode && emojiWithCategory.category ? 'hide-offscreen' : ''}"
+          <div class="emoji-menu ${hideOffscreen ? 'hide-offscreen' : ''}"
                style=${`--num-rows: ${Math.ceil(emojiWithCategory.emojis.length / state.numColumns)}`}
+               data-action="${hideOffscreen ? 'updateOnContentVisibilityChange' : ''}"
                role="${state.searchMode ? 'listbox' : 'menu'}"
                aria-labelledby="menu-label-${i}"
                id=${state.searchMode ? 'search-results' : ''}
@@ -226,17 +233,17 @@ export function render (container, state, helpers, events, actions, refs, abortS
 
   const rootDom = section()
 
+  // helper for traversing the dom, finding elements by an attribute, and getting the attribute value
+  const forElementWithAttribute = (attributeName, callback) => {
+    for (const element of container.querySelectorAll(`[${attributeName}]`)) {
+      callback(element, element.getAttribute(attributeName))
+    }
+  }
+
   if (firstRender) { // not a re-render
     container.appendChild(rootDom)
 
-    // we only bind events/refs/actions once - there is no need to find them again given this component structure
-
-    // helper for traversing the dom, finding elements by an attribute, and getting the attribute value
-    const forElementWithAttribute = (attributeName, callback) => {
-      for (const element of container.querySelectorAll(`[${attributeName}]`)) {
-        callback(element, element.getAttribute(attributeName))
-      }
-    }
+    // we only bind events/refs once - there is no need to find them again given this component structure
 
     // bind events
     for (const eventName of ['click', 'focusout', 'input', 'keydown', 'keyup']) {
@@ -250,14 +257,26 @@ export function render (container, state, helpers, events, actions, refs, abortS
       refs[ref] = element
     })
 
-    // set up actions
-    forElementWithAttribute('data-action', (element, action) => {
-      actions[action](element)
-    })
-
     // destroy/abort logic
     abortSignal.addEventListener('abort', () => {
       container.removeChild(rootDom)
     })
   }
+
+  // set up actions
+  forElementWithAttribute('data-action', (element, action) => {
+    if (!action) {
+      return // `data-action` may be set to the empty string, meaning don't do anything
+    }
+    let boundActions = actionContext[action]
+    if (!boundActions) {
+      boundActions = actionContext[action] = new WeakSet()
+    }
+
+    // avoid applying the same action to the same element multiple times
+    if (!boundActions.has(element)) {
+      boundActions.add(element)
+      actions[action](element)
+    }
+  })
 }

--- a/src/picker/components/Picker/PickerTemplate.js
+++ b/src/picker/components/Picker/PickerTemplate.js
@@ -17,7 +17,7 @@ export function render (container, state, helpers, events, actions, refs, abortS
                 (emoji.unicode ? '' : ' custom-emoji')
               }"
               id=${`${prefix}-${emoji.id}`}
-              style="${`--custom-emoji-background: url(${JSON.stringify(emoji.url)})`}"
+              style="${emoji.unicode ? '' : `--custom-emoji-background: url(${JSON.stringify(emoji.url)})`}"
       >
         ${
         emoji.unicode

--- a/src/picker/components/Picker/PickerTemplate.js
+++ b/src/picker/components/Picker/PickerTemplate.js
@@ -264,11 +264,11 @@ export function render (container, state, helpers, events, actions, refs, abortS
     })
   }
 
-  // set up actions
+  // set up actions - these are re-bound on every render
   forElementWithAttribute('data-action', (element, action) => {
-    let boundActions = actionContext[action]
+    let boundActions = actionContext.get(action)
     if (!boundActions) {
-      boundActions = actionContext[action] = new WeakSet()
+      actionContext.set(action, (boundActions = new WeakSet()))
     }
 
     // avoid applying the same action to the same element multiple times

--- a/src/picker/styles/picker.scss
+++ b/src/picker/styles/picker.scss
@@ -129,11 +129,17 @@ button.emoji,
     background-repeat: no-repeat;
     background-position: center center;
     background-size: contain;
-    background-image: var(--custom-emoji-background);
 
     // Don't eagerly download the images while the custom emoji is offscreen
-    .hide-offscreen:not(.onscreen) & {
+    .hide-offscreen & {
       background-image: none;
+    }
+
+    // Note we have to handle the case of the favorites bar, which has no `.onscreen` or `.hide-offscreen` in its
+    // ancestor tree. The specificity/ordering here is deliberate.
+    // We could use `.hide-offscreen:not(.onscreen) &` above instead, but avoiding `:not()` here for selector perf.
+    &, .onscreen & {
+      background-image: var(--custom-emoji-background);
     }
   }
 }

--- a/src/picker/styles/picker.scss
+++ b/src/picker/styles/picker.scss
@@ -117,14 +117,25 @@ button.emoji,
 }
 
 .custom-emoji {
-  height: var(--total-emoji-size);
-  width: var(--total-emoji-size);
-  padding: var(--emoji-padding);
-  object-fit: contain;
-  pointer-events: none;
-  background-repeat: no-repeat;
-  background-position: center center;
-  background-size: var(--emoji-size) var(--emoji-size);
+  position: relative;
+
+  &::after {
+    content: '';
+    position: absolute;
+    left: var(--emoji-padding);
+    right: var(--emoji-padding);
+    top: var(--emoji-padding);
+    bottom: var(--emoji-padding);
+    background-repeat: no-repeat;
+    background-position: center center;
+    background-size: contain;
+    background-image: var(--custom-emoji-background);
+
+    // Don't eagerly download the images while the custom emoji is offscreen
+    .hide-offscreen:not(.onscreen) & {
+      background-image: none;
+    }
+  }
 }
 
 // nav

--- a/src/picker/styles/picker.scss
+++ b/src/picker/styles/picker.scss
@@ -116,31 +116,24 @@ button.emoji,
   }
 }
 
-.custom-emoji {
-  position: relative;
+.custom-emoji::after {
+  content: '';
+  width: var(--emoji-size);
+  height: var(--emoji-size);
+  background-repeat: no-repeat;
+  background-position: center center;
+  background-size: contain;
 
-  &::after {
-    content: '';
-    position: absolute;
-    left: var(--emoji-padding);
-    right: var(--emoji-padding);
-    top: var(--emoji-padding);
-    bottom: var(--emoji-padding);
-    background-repeat: no-repeat;
-    background-position: center center;
-    background-size: contain;
+  // Don't eagerly download the images while the custom emoji is offscreen
+  .hide-offscreen & {
+    background-image: none;
+  }
 
-    // Don't eagerly download the images while the custom emoji is offscreen
-    .hide-offscreen & {
-      background-image: none;
-    }
-
-    // Note we have to handle the case of the favorites bar, which has no `.onscreen` or `.hide-offscreen` in its
-    // ancestor tree. The specificity/ordering here is deliberate.
-    // We could use `.hide-offscreen:not(.onscreen) &` above instead, but avoiding `:not()` here for selector perf.
-    &, .onscreen & {
-      background-image: var(--custom-emoji-background);
-    }
+  // Note we have to handle the case of the favorites bar, which has no `.onscreen` or `.hide-offscreen` in its
+  // ancestor tree. The specificity/ordering here is deliberate.
+  // We could use `.hide-offscreen:not(.onscreen) &` above instead, but avoiding `:not()` here for selector perf.
+  &, .onscreen & {
+    background-image: var(--custom-emoji-background);
   }
 }
 

--- a/src/picker/utils/contentVisibilityAction.js
+++ b/src/picker/utils/contentVisibilityAction.js
@@ -1,0 +1,13 @@
+/* istanbul ignore next */
+const SUPPORTS_CONTENT_VISIBILITY = import.meta.env.MODE !== 'test' && CSS.supports('content-visibility', 'auto')
+
+export function contentVisibilityAction (node, signal, listener) {
+  /* istanbul ignore if */
+  if (SUPPORTS_CONTENT_VISIBILITY) {
+    node.addEventListener('contentvisibilityautostatechange', listener, { signal })
+  } else {
+    // If content visibility is unsupported, then just treat every element as always visible.
+    // This browser will just not get the optimization
+    listener({ skipped: false })
+  }
+}

--- a/src/picker/utils/contentVisibilityAction.js
+++ b/src/picker/utils/contentVisibilityAction.js
@@ -16,8 +16,8 @@ export function contentVisibilityAction (node, abortSignal, listener) {
       // old Safari versions if they eagerly downloaded all custom emoji all at once.
       observer = new IntersectionObserver(listener, {
         root,
-        // trigger if we are one scroll container height away so that the images load a bit quicker while scrolling
-        rootMargin: '100% 0px 100% 0px',
+        // trigger if we are 1/2 scroll container height away so that the images load a bit quicker while scrolling
+        rootMargin: '50% 0px 50% 0px',
         // trigger if any part of the emoji grid is intersecting
         threshold: 0
       })

--- a/src/picker/utils/contentVisibilityAction.js
+++ b/src/picker/utils/contentVisibilityAction.js
@@ -1,10 +1,11 @@
 /* istanbul ignore next */
 const SUPPORTS_CONTENT_VISIBILITY = import.meta.env.MODE !== 'test' && CSS.supports('content-visibility', 'auto')
 
-export function contentVisibilityAction (node, signal, listener) {
+export function contentVisibilityAction (node, listener) {
   /* istanbul ignore if */
   if (SUPPORTS_CONTENT_VISIBILITY) {
-    node.addEventListener('contentvisibilityautostatechange', listener, { signal })
+    // Note we don't need an abortSignal here because if the node is removed then the event listener is also GC'ed
+    node.addEventListener('contentvisibilityautostatechange', listener)
   } else {
     // If content visibility is unsupported, then just treat every element as always visible.
     // This browser will just not get the optimization

--- a/src/picker/utils/intersectionObserverAction.js
+++ b/src/picker/utils/intersectionObserverAction.js
@@ -1,6 +1,6 @@
 const intersectionObserverCache = new WeakMap()
 
-export function contentVisibilityAction (node, abortSignal, listener) {
+export function intersectionObserverAction (node, abortSignal, listener) {
   /* istanbul ignore else */
   if (import.meta.env.MODE === 'test') {
     // jsdom doesn't support intersection observer; just fake it
@@ -22,6 +22,7 @@ export function contentVisibilityAction (node, abortSignal, listener) {
         threshold: 0
       })
 
+      // avoid creating a new IntersectionObserver for every category; just use one for the whole root
       intersectionObserverCache.set(root, observer)
 
       // assume that the abortSignal is always the same for this root node; just add one event listener

--- a/test/adhoc/index.html
+++ b/test/adhoc/index.html
@@ -86,6 +86,24 @@
         worker.postMessage('init')
       })
     }
+
+    if (new URLSearchParams(location.search).has('custom')) {
+      // enable custom emoji
+      const categoriesToCustomEmoji = (await (await fetch('/docs/custom.json')).json())
+      const customEmoji = []
+      for (const [category, names] of Object.entries(categoriesToCustomEmoji)) {
+        for (const name of names) {
+          customEmoji.push({
+            category: category || undefined,
+            name,
+            shortcodes: [name],
+            url: `/docs/custom/${name}.svg`
+          })
+        }
+      }
+      opts.customEmoji = customEmoji
+    }
+
     const picker = new Picker(opts)
     picker.addEventListener('emoji-click', e => console.log(e))
     document.body.appendChild(picker)


### PR DESCRIPTION
This is a variation on #449 but with a few tweaks:

- Instead of rendering an `<img>` at all, we use `background-image`. This reduces the total number of elements needed to render 20k emojis by half (20k instead of 40k)
- Use ~~`contentvisibilityautostatechange`~~ `IntersectionObserver` to toggle a CSS class which controls whether the background image is shown or not. This simulates what `<img loading=lazy>` was doing for us but without an `<img>`.