### PR TITLE
fix: fix favorites `aria-selected` rendering

### DIFF
--- a/src/picker/components/Picker/PickerTemplate.js
+++ b/src/picker/components/Picker/PickerTemplate.js
@@ -8,7 +8,7 @@ export function render (container, state, helpers, events, actions, refs, abortS
     return map(emojis, (emoji, i) => {
       return html`
       <button role="${searchMode ? 'option' : 'menuitem'}"
-              aria-selected="${state.searchMode ? i === state.activeSearchItem : ''}"
+              aria-selected="${searchMode ? i === state.activeSearchItem : ''}"
               aria-label="${labelWithSkin(emoji, state.currentSkinTone)}"
               title="${titleForEmoji(emoji)}"
               class="emoji ${searchMode && i === state.activeSearchItem ? 'active' : ''}"


### PR DESCRIPTION
Random dumb bug I noticed – the favorites should not have their `aria-selected` rendered at all, even if something is selected in the main panel.