### PR TITLE
fix: fix resetting `scrollTop`

### DIFF
--- a/src/picker/components/Picker/Picker.js
+++ b/src/picker/components/Picker/Picker.js
@@ -424,6 +424,11 @@ export function createRoot (shadowRoot, props) {
     /* no await */ updateEmojis()
   })
 
+  const resetScrollTopInRaf = () => {
+    // Reset scroll top to 0 when emojis change
+    requestAnimationFrame(() => resetScrollTopIfPossible(refs.tabpanelElement))
+  }
+
   // Some emojis have their ligatures rendered as two or more consecutive emojis
   // We want to treat these the same as unsupported emojis, so we compare their
   // widths against the baseline widths and remove them as necessary
@@ -439,14 +444,16 @@ export function createRoot (shadowRoot, props) {
     } else {
       const newEmojis = emojiVersion ? currentEmojis : currentEmojis.filter(isZwjSupported)
       updateCurrentEmojis(newEmojis)
-      // Reset scroll top to 0 when emojis change
-      requestAnimationFrame(() => resetScrollTopIfPossible(refs.tabpanelElement))
+      resetScrollTopInRaf()
     }
   })
 
   function checkZwjSupportAndUpdate (zwjEmojisToCheck) {
     const allSupported = checkZwjSupport(zwjEmojisToCheck, refs.baselineEmoji, emojiToDomNode)
-    if (!allSupported) {
+    if (allSupported) {
+      // Even if all emoji are supported, we still need to reset the scroll top to 0 when emojis change
+      resetScrollTopInRaf()
+    } else {
       console.log('Not all ZWJ emoji are supported, forcing re-render')
       // Force update. We only do this if there are any unsupported ZWJ characters since otherwise,
       // for browsers that support all emoji, it would be an unnecessary extra re-render.

--- a/src/picker/components/Picker/Picker.js
+++ b/src/picker/components/Picker/Picker.js
@@ -425,7 +425,6 @@ export function createRoot (shadowRoot, props) {
   })
 
   const resetScrollTopInRaf = () => {
-    // Reset scroll top to 0 when emojis change
     requestAnimationFrame(() => resetScrollTopIfPossible(refs.tabpanelElement))
   }
 
@@ -444,6 +443,7 @@ export function createRoot (shadowRoot, props) {
     } else {
       const newEmojis = emojiVersion ? currentEmojis : currentEmojis.filter(isZwjSupported)
       updateCurrentEmojis(newEmojis)
+      // Reset scroll top to 0 when emojis change
       resetScrollTopInRaf()
     }
   })

--- a/src/picker/utils/resetScrollTopIfPossible.js
+++ b/src/picker/utils/resetScrollTopIfPossible.js
@@ -7,5 +7,8 @@ export function resetScrollTopIfPossible (element) {
   /* istanbul ignore else */
   if (element) { // Makes me nervous not to have this `if` guard
     element.scrollTop = 0
+    console.log('reset scrollTop to 0')
+  } else {
+    console.log('could not reset scrollTop')
   }
 }


### PR DESCRIPTION
Another dumb bug that snuck in at some point (probably #437). If all ZWJ emoji are supported, then we don't re-render and thus never reset the `scrollTop`. This fixes that.

Repro:

1. Scroll down
2. Click to another tab
3. We should be scrolled to the top now