### PR TITLE
perf: optimize setting attributes

### DIFF
--- a/src/picker/components/Picker/PickerTemplate.js
+++ b/src/picker/components/Picker/PickerTemplate.js
@@ -8,7 +8,7 @@ export function render (container, state, helpers, events, actions, refs, abortS
     return map(emojis, (emoji, i) => {
       return html`
       <button role="${searchMode ? 'option' : 'menuitem'}"
-              aria-selected="${searchMode ? i === state.activeSearchItem : ''}"
+              aria-selected="${searchMode ? i === state.activeSearchItem : undefined}"
               aria-label="${labelWithSkin(emoji, state.currentSkinTone)}"
               title="${titleForEmoji(emoji)}"
               class="${
@@ -17,7 +17,7 @@ export function render (container, state, helpers, events, actions, refs, abortS
                 (emoji.unicode ? '' : ' custom-emoji')
               }"
               id=${`${prefix}-${emoji.id}`}
-              style="${emoji.unicode ? '' : `--custom-emoji-background: url(${JSON.stringify(emoji.url)})`}"
+              style=${emoji.unicode ? undefined : `--custom-emoji-background: url(${JSON.stringify(emoji.url)})`}
       >
         ${
         emoji.unicode
@@ -59,7 +59,7 @@ export function render (container, state, helpers, events, actions, refs, abortS
             aria-controls="search-results"
             aria-describedby="search-description"
             aria-autocomplete="list"
-            aria-activedescendant="${state.activeSearchItemId ? `emo-${state.activeSearchItemId}` : ''}"
+            aria-activedescendant="${state.activeSearchItemId ? `emo-${state.activeSearchItemId}` : undefined}"
             data-ref="searchElement"
             data-on-input="onSearchInput"
             data-on-keydown="onSearchKeydown"
@@ -162,7 +162,7 @@ export function render (container, state, helpers, events, actions, refs, abortS
              class="tabpanel ${(!state.databaseLoaded || state.message) ? 'gone' : ''}"
              role="${state.searchMode ? 'region' : 'tabpanel'}"
              aria-label="${state.searchMode ? state.i18n.searchResultsLabel : state.i18n.categories[state.currentGroup.name]}"
-             id="${state.searchMode ? '' : `tab-${state.currentGroup.id}`}"
+             id=${state.searchMode ? undefined : `tab-${state.currentGroup.id}`}
              tabIndex="0"
              data-on-click="onEmojiClick"
         >
@@ -211,7 +211,7 @@ export function render (container, state, helpers, events, actions, refs, abortS
                data-action="updateOnIntersection"
                role="${state.searchMode ? 'listbox' : 'menu'}"
                aria-labelledby="menu-label-${i}"
-               id=${state.searchMode ? 'search-results' : ''}
+               id=${state.searchMode ? 'search-results' : undefined}
           >
             ${
               emojiList(emojiWithCategory.emojis, state.searchMode, /* prefix */ 'emo')

--- a/src/picker/components/Picker/framework.js
+++ b/src/picker/components/Picker/framework.js
@@ -79,6 +79,10 @@ function patch (expressions, instanceBindings) {
 
     const expression = expressions[expressionIndex]
 
+    if (import.meta.env.MODE !== 'production' && expression === undefined && (attributeValuePre || attributeValuePost)) {
+      throw new Error('framework does not support undefined expressions with attribute pre/post')
+    }
+
     if (currentExpression === expression) {
       // no need to update, same as before
       continue

--- a/src/picker/components/Picker/framework.js
+++ b/src/picker/components/Picker/framework.js
@@ -91,7 +91,7 @@ function patch (expressions, instanceBindings) {
     instanceBinding.currentExpression = expression
 
     if (attributeName) { // attribute replacement
-      if (!attributeValuePre && !attributeValuePost && expression === undefined) {
+      if (expression === undefined) {
         // undefined is treated as a special case by the framework - we don't render an attribute at all in this case
         targetNode.removeAttribute(attributeName)
       } else {

--- a/test/spec/picker/framework.test.js
+++ b/test/spec/picker/framework.test.js
@@ -76,6 +76,70 @@ describe('framework', () => {
     expect(node.outerHTML).toBe('<div>baz</div>')
   })
 
+  test('set to undefined then something then back to undefined', () => {
+    const state = { value: undefined }
+    const { html } = createFramework(state)
+
+    let node
+    const render = () => {
+      node = html`<div aria-selected=${state.value}></div>`
+    }
+
+    render()
+    expect(node.getAttribute('aria-selected')).toBe(null)
+
+    state.value = true
+    render()
+    expect(node.getAttribute('aria-selected')).toBe('true')
+
+    state.value = undefined
+    render()
+    expect(node.getAttribute('aria-selected')).toBe(null)
+  })
+
+  test('set to undefined then something then back to undefined - with quotes', () => {
+    const state = { value: undefined }
+    const { html } = createFramework(state)
+
+    let node
+    const render = () => {
+      node = html`<div aria-selected="${state.value}"></div>`
+    }
+
+    render()
+    expect(node.getAttribute('aria-selected')).toBe(null)
+
+    state.value = true
+    render()
+    expect(node.getAttribute('aria-selected')).toBe('true')
+
+    state.value = undefined
+    render()
+    expect(node.getAttribute('aria-selected')).toBe(null)
+  })
+
+  test('set to undefined then something then back to undefined - with pre/post text', () => {
+    const state = { value: undefined }
+    const { html } = createFramework(state)
+
+    let node
+    const render = () => {
+      node = html`<div class="foo ${state.value} bar"></div>`
+    }
+
+    render()
+    // expect(node.getAttribute('class')).toBe('foo undefined bar')
+    expect(node.getAttribute('class')).toBe(null) // we don't handle the initial undefined case correctly
+
+    state.value = true
+    render()
+    expect(node.getAttribute('class')).toBe('foo true bar')
+
+    state.value = undefined
+    render()
+    expect(node.getAttribute('class')).toBe('foo undefined bar')
+  })
+
   // Framework no longer supports this since we switched from HTML comments to text nodes
   test.skip('render two dynamic expressions inside the same element', () => {
     const state = { name1: 'foo', name2: 'bar' }

--- a/test/spec/picker/framework.test.js
+++ b/test/spec/picker/framework.test.js
@@ -118,26 +118,18 @@ describe('framework', () => {
     expect(node.getAttribute('aria-selected')).toBe(null)
   })
 
-  test('set to undefined then something then back to undefined - with pre/post text', () => {
+  test('set to undefined - with pre/post text', () => {
     const state = { value: undefined }
     const { html } = createFramework(state)
 
-    let node
-    const render = () => {
-      node = html`<div class="foo ${state.value} bar"></div>`
+    const renders = [
+      () => html`<div class="foo ${state.value}"></div>`,
+      () => html`<div class="${state.value} bar"></div>`,
+      () => html`<div class="foo ${state.value} bar"></div>`
+    ]
+    for (const render of renders) {
+      expect(render).toThrow(/framework does not support undefined expressions with attribute pre\/post/)
     }
-
-    render()
-    // expect(node.getAttribute('class')).toBe('foo undefined bar')
-    expect(node.getAttribute('class')).toBe(null) // we don't handle the initial undefined case correctly
-
-    state.value = true
-    render()
-    expect(node.getAttribute('class')).toBe('foo true bar')
-
-    state.value = undefined
-    render()
-    expect(node.getAttribute('class')).toBe('foo undefined bar')
   })
 
   // Framework no longer supports this since we switched from HTML comments to text nodes


### PR DESCRIPTION
Very slight pref optimization, adds some complexity, but may be worth the tradeoff. Also avoids rendering useless empty attributes like `aria-selected=''`.