### PR TITLE
chore(ci): use ubuntu 22.04 for now

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,8 @@ on:
     branches: [ master ]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # Hopefully temporary fix for Puppeteer "No usable sandbox!" error which we get on Ubuntu 24.04+
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - run: corepack enable


### PR DESCRIPTION
The memory leak tests are now giving this error due to Puppeteer running in Ubuntu 24.04:

```
Error: Failed to launch the browser process!
[3197:3197:1214/235227.041856:FATAL:zygote_host_impl_linux.cc(128)] No usable sandbox! If you are running on Ubuntu 23.10+ or another Linux distro that has disabled unprivileged user namespaces with AppArmor, see https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md. Otherwise see https://chromium.googlesource.com/chromium/src/+/main/docs/linux/suid_sandbox_development.md for more information on developing with the (older) SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.
[1214/235227.049018:ERROR:file_io_posix.cc(145)] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq: No such file or directory (2)
[1214/235227.049060:ERROR:file_io_posix.cc(145)] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq: No such file or directory (2)
```

I can't be bothered to figure out which magic incantation I need to get this to work, so let's just switch to Ubuntu 22.04. Once 22.04 is EOL I'm sure there will be more Google hits for this problem.