### PR TITLE
Add js extensions to imports in type definitions

### DIFF
--- a/database.d.ts
+++ b/database.d.ts
@@ -1,4 +1,4 @@
-import { Emoji, DatabaseConstructorOptions, SkinTone, CustomEmoji, NativeEmoji } from "./shared";
+import { Emoji, DatabaseConstructorOptions, SkinTone, CustomEmoji, NativeEmoji } from "./shared.js";
 export default class Database {
     /**
      * Create a new Database.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
-import Picker from './picker'
-import Database from './database'
+import Picker from './picker.js'
+import Database from './database.js'
 
 export {
   Picker,

--- a/picker.d.ts
+++ b/picker.d.ts
@@ -1,4 +1,4 @@
-import { I18n, PickerConstructorOptions, EmojiPickerEventMap, CustomEmoji } from "./shared";
+import { I18n, PickerConstructorOptions, EmojiPickerEventMap, CustomEmoji } from "./shared.js";
 export default class Picker extends HTMLElement {
     dataSource: string;
     locale: string;

--- a/trimEmojiData.d.ts
+++ b/trimEmojiData.d.ts
@@ -1,4 +1,4 @@
-import { Emoji } from "./shared";
+import { Emoji } from "./shared.js";
 /**
  * Given an array of emoji (e.g. emojibase-data/en/data.json), extract out only the data
  * needed for emoji-picker-element, resulting in a smaller object.


### PR DESCRIPTION
In TypeScript projects using `moduleResolution: node16`, emoji-picker-element's types aren't interpreted correctly. The problem is that the types are using extensionless relative imports, and extensions are required with node16 moduleResolution.

Since it appears the types are hand-authored, the fix is straightforward - add the .js extension to the imports in the types file. I have confirmed that this change makes this package usable in TypeScript projects with moduleResolution: node16, and in general bundlers handle both forms so it shouldn't matter to other uses.

There is a lot more information about why things work this way at <https://www.typescriptlang.org/docs/handbook/modules/theory.html#typescript-imitates-the-hosts-module-resolution-but-with-types> but the short version is that TypeScript with this setting resolves exactly like node does, just with the type files. So while this package is unlikely to be run in node, the types may be used in an environment that where TypeScript expects them to resolve like node modules would.