### PR TITLE
fix: better handling of race conditions

### DIFF
--- a/src/database/dataLoading.js
+++ b/src/database/dataLoading.js
@@ -2,7 +2,7 @@ import { getETag, getETagAndData } from './utils/ajax'
 import { jsonChecksum } from './utils/jsonChecksum'
 import { hasData, loadData } from './idbInterface'
 
-export async function checkForUpdates (db, dataSource) {
+async function doCheckForUpdates (db, dataSource) {
   // just do a simple HEAD request first to see if the eTags match
   let emojiData
   let eTag = await getETag(dataSource)
@@ -35,4 +35,16 @@ export async function loadDataForFirstTime (db, dataSource) {
   }
 
   await loadData(db, emojiData, dataSource, eTag)
+}
+
+export async function checkForUpdates (db, dataSource) {
+  try {
+    await doCheckForUpdates(db, dataSource)
+  } catch (err) {
+    // Checking for updates is not a critical operation, and it can fail if e.g. the picker is quickly removed
+    // and re-added to the DOM. We can safely ignore IndexedDB InvalidStateErrors here
+    if (err.name !== 'InvalidStateError') {
+      throw err
+    }
+  }
 }

--- a/src/picker/utils/checkZwjSupport.js
+++ b/src/picker/utils/checkZwjSupport.js
@@ -22,7 +22,6 @@ export function checkZwjSupport (zwjEmojisToCheck, baselineEmoji, emojiToDomNode
   for (const emoji of zwjEmojisToCheck) {
     const domNode = emojiToDomNode(emoji)
     // sanity check to make sure the node is defined properly
-    /* istanbul ignore if */
     if (!domNode) {
       // This is a race condition that can occur when the component is unmounted/remounted
       // It doesn't really matter what we do here since the old context is not going to render anymore.

--- a/test/spec/picker/raceConditions.test.js
+++ b/test/spec/picker/raceConditions.test.js
@@ -1,0 +1,83 @@
+import { basicBeforeEach, basicAfterEach, ALL_EMOJI, truncatedEmoji, tick } from '../shared'
+import * as testingLibrary from '@testing-library/dom'
+import Picker from '../../../src/picker/PickerElement.js'
+import userEvent from '@testing-library/user-event'
+import Database from '../../../src/database/Database'
+import { requestAnimationFrame } from '../../../src/picker/utils/requestAnimationFrame.js'
+
+const { waitFor } = testingLibrary
+const { click } = userEvent
+
+describe('Race conditions', () => {
+  let picker
+  let container
+
+  const proxy = new Proxy(testingLibrary, {
+    get (obj, prop) {
+      return function (...args) {
+        return obj[prop](container, ...args)
+      }
+    }
+  })
+  const { getByRole } = proxy
+
+  const numInGroup1 = truncatedEmoji.filter(_ => _.group === 0).length
+
+  beforeEach(async () => {
+    basicBeforeEach()
+    picker = new Picker({ dataSource: ALL_EMOJI, locale: 'en' })
+    document.body.appendChild(picker)
+    container = picker.shadowRoot.querySelector('.picker')
+    await tick(20)
+    await waitFor(() => expect(
+      testingLibrary.getAllByRole(getByRole('tabpanel'), 'menuitem')).toHaveLength(numInGroup1),
+    { timeout: 2000 }
+    )
+    await tick(20)
+  })
+  afterEach(async () => {
+    await tick(20)
+    picker.remove()
+    await tick(20)
+    await new Database({ dataSource: ALL_EMOJI, locale: 'en' }).delete()
+    await tick(20)
+    await basicAfterEach()
+  })
+
+  test('Immediately remove and re-add a new picker element', async () => {
+    picker.remove()
+    picker = new Picker({ dataSource: ALL_EMOJI, locale: 'en' })
+    document.body.appendChild(picker)
+  })
+
+  test('Immediately remove and re-add a new picker element - tick between each', async () => {
+    for (let i = 0; i < 2; i++) {
+      picker.remove()
+      await tick(i)
+      picker = new Picker({ dataSource: ALL_EMOJI, locale: 'en' })
+      document.body.appendChild(picker)
+    }
+  })
+
+  test('Click tab and then immediately remove picker with various timings', async () => {
+    const delays = [
+      undefined,
+      () => new Promise(requestAnimationFrame),
+      () => tick(0),
+      () => tick(1),
+      () => tick(2)
+    ]
+    for (const delay of delays) {
+      /* no await */ click(getByRole('tab', { name: 'Animals and nature' }))
+      if (delay) {
+        await delay()
+      }
+      // remove
+      picker.remove()
+      // recreate
+      picker = new Picker({ dataSource: ALL_EMOJI, locale: 'en' })
+      document.body.appendChild(picker)
+      container = picker.shadowRoot.querySelector('.picker')
+    }
+  })
+})


### PR DESCRIPTION
There are lots of race conditions that can arise from e.g. quickly removing and re-adding the picker, or removing and creating a new one. This seems to come up a lot in people's unit tests, which makes sense, because they're rapidly removing and adding stuff from the DOM.

Previously I was kind of sloppy about this, and mostly just throwing errors asynchronously – which is largely harmless, but can put unnecessary noise in the console. Maybe we can do some better error handling to clean up the noise.