### PR TITLE
feat: add `emoji-click-sync` event as Safari workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A lightweight emoji picker, distributed as a web component.
     + [Picker](#picker)
       - [Events](#events)
         * [`emoji-click`](#emoji-click)
-      - [`emoji-click-sync`](#emoji-click-sync)
+        * [`emoji-click-sync`](#emoji-click-sync)
         * [`skin-tone-change`](#skin-tone-change)
       - [Internationalization](#internationalization)
         * [Built-in translations](#built-in-translations)
@@ -407,7 +407,7 @@ Note that `unicode` will represent whatever the emoji should look like
 with the given `skinTone`. If the `skinTone` is 0, or if the emoji has
 no skin tones, then no skin tone is applied to `unicode`.
 
-#### `emoji-click-sync`
+##### `emoji-click-sync`
 
 > [!NOTE]  
 > You likely only need this event if you need to copy the emoji to the clipboard,

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ A lightweight emoji picker, distributed as a web component.
     + [Picker](#picker)
       - [Events](#events)
         * [`emoji-click`](#emoji-click)
+      - [`emoji-click-sync`](#emoji-click-sync)
         * [`skin-tone-change`](#skin-tone-change)
       - [Internationalization](#internationalization)
         * [Built-in translations](#built-in-translations)

--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ no skin tones, then no skin tone is applied to `unicode`.
 ##### `emoji-click-sync`
 
 > [!NOTE]  
-> You likely only need this event if you need to copy the emoji to the clipboard,
+> Most likely, you should only use this event if you need to copy an emoji to the clipboard,
 > due to [a Safari bug](https://github.com/nolanlawson/emoji-picker-element/issues/281#issuecomment-3256832247).
 
 The `emoji-click-sync` event is exactly the same as `emoji-click`, except that the event is fired
@@ -426,7 +426,7 @@ This is useful to work around [a Safari bug](https://github.com/nolanlawson/emoj
 when using the [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard), which causes 
 the error `NotAllowedError: The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.`
 
-Correct usage to avoid the error:
+Example usage to copy an emoji to the clipboard:
 
 ```js
 picker.addEventListener('emoji-click-sync', async event => {

--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ synchronously relative to the original `'click'` event, and the `event.detail` i
 ```js
 picker.addEventListener('emoji-click-sync', async event => {
   console.log(await event.detail); // same as above
-})
+});
 ```
 
 This is useful to work around [a Safari bug](https://github.com/nolanlawson/emoji-picker-element/issues/281#issuecomment-3256832247)

--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ no skin tones, then no skin tone is applied to `unicode`.
 > due to [a Safari bug](https://github.com/nolanlawson/emoji-picker-element/issues/281#issuecomment-3256832247).
 
 The `emoji-click-sync` event is exactly the same as `emoji-click`, except that the event is fired
-synchronously and the `event.detail` is a `Promise` that must be `await`ed:
+synchronously relative to the original `'click'` event, and the `event.detail` is a `Promise` that must be `await`ed:
 
 ```js
 picker.addEventListener('emoji-click-sync', async event => {
@@ -425,8 +425,10 @@ picker.addEventListener('emoji-click-sync', async event => {
 This is useful to work around [a Safari bug](https://github.com/nolanlawson/emoji-picker-element/issues/281#issuecomment-3256832247)
 when using the [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard), which causes 
 the error `NotAllowedError: The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.`
+This error occurs due to Safari not recognizing than the event is user-initiated due to the presence of
+`await`s for IndexedDB data.
 
-Example usage to copy an emoji to the clipboard:
+Example of correct usage to copy an emoji to the clipboard:
 
 ```js
 picker.addEventListener('emoji-click-sync', async event => {

--- a/README.md
+++ b/README.md
@@ -425,7 +425,7 @@ picker.addEventListener('emoji-click-sync', async event => {
 This is useful to work around [a Safari bug](https://github.com/nolanlawson/emoji-picker-element/issues/281#issuecomment-3256832247)
 when using the [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard), which causes 
 the error `NotAllowedError: The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.`
-This error occurs due to Safari not recognizing than the event is user-initiated due to the presence of
+This error occurs due to Safari not recognizing that the `emoji-click` event is user-initiated due to the presence of
 `await`s for IndexedDB data.
 
 Example of correct usage to copy an emoji to the clipboard:

--- a/README.md
+++ b/README.md
@@ -406,6 +406,42 @@ Note that `unicode` will represent whatever the emoji should look like
 with the given `skinTone`. If the `skinTone` is 0, or if the emoji has
 no skin tones, then no skin tone is applied to `unicode`.
 
+#### `emoji-click-sync`
+
+> [!NOTE]  
+> You likely only need this event if you need to copy the emoji to the clipboard,
+> due to [a Safari bug](https://github.com/nolanlawson/emoji-picker-element/issues/281#issuecomment-3256832247).
+
+The `emoji-click-sync` event is exactly the same as `emoji-click`, except that the event is fired
+synchronously and the `event.detail` is a `Promise` that must be `await`ed:
+
+```js
+picker.addEventListener('emoji-click-sync', async event => {
+  console.log(await event.detail); // same as above
+})
+```
+
+This is useful to work around [a Safari bug](https://github.com/nolanlawson/emoji-picker-element/issues/281#issuecomment-3256832247)
+when using the [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard), which causes 
+the error `NotAllowedError: The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.`
+
+Correct usage to avoid the error:
+
+```js
+picker.addEventListener('emoji-click-sync', async event => {
+  try {
+    await navigator.clipboard.write([new ClipboardItem({
+      'text/plain': e.detail.then(({ unicode }) => unicode),
+    })]);
+    console.log('Copied to clipboard!');
+  } catch (err) {
+    console.log('Failed to copy to clipboard', err);
+  }
+});
+```
+
+If you don't need to work around the Safari bug, then you can just use the `emoji-click` event instead.
+
 ##### `skin-tone-change`
 
 This event is fired whenever the user selects a new skin tone. Example format:

--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ no skin tones, then no skin tone is applied to `unicode`.
 > due to [a Safari bug](https://github.com/nolanlawson/emoji-picker-element/issues/281#issuecomment-3256832247).
 
 The `emoji-click-sync` event is exactly the same as `emoji-click`, except that the event is fired
-synchronously relative to the original `'click'` event, and the `event.detail` is a `Promise` that must be `await`ed:
+synchronously relative to the original `click` event, and the `event.detail` is a `Promise` that must be `await`ed:
 
 ```js
 picker.addEventListener('emoji-click-sync', async event => {

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -89,6 +89,10 @@
             {
               "name": "emoji-click",
               "description": "The `emoji-click` event is fired when an emoji is selected by the user."
+            },
+            {
+              "name": "emoji-click-sync",
+              "description": "The `emoji-click-sync` event is fired synchronously when an emoji is selected by the user. Use this when copying data to the clipboard using the Clipboard API to work around a Safari bug."
             }
           ],
           "cssProperties": [

--- a/docs/index.html
+++ b/docs/index.html
@@ -80,7 +80,10 @@
     details {
         display: flex;
         flex-direction: column;
-        gap: 20px;
+    }
+
+    summary {
+        padding-bottom: 20px;
     }
 
     footer {
@@ -291,21 +294,32 @@
     const alert = $('[role="alert"]')
     const pre = $('pre')
     const summary = $('summary')
-    const onEvent = async e => {
-      console.log(e)
-      alert.classList.add('shown')
-      pre.innerHTML = `Event: ${JSON.stringify(e.type)}\n\nData:\n\n${JSON.stringify(e.detail, null, 2)}`
+
+    const copyToClipboard = async e => {
+      // fun workaround for a safari bug: https://github.com/nolanlawson/emoji-picker-element/issues/281
+      // use emoji-click-sync and then write the promise to the navigator.clipboard to avoid a NotAllowedError
       try {
         await navigator.clipboard.write([new ClipboardItem({
-          'text/plain': e.detail.unicode,
-        })]);
+          'text/plain': e.detail.then(({ unicode }) => unicode),
+        })])
         summary.textContent = `Copied to clipboard! Details:`
       } catch (err) {
         console.log(err)
         summary.textContent = `Failed to write to the clipboard! Event details:`
       }
     }
-    picker.addEventListener('emoji-click', onEvent)
+
+    const log = async e => {
+      const detail = await e.detail
+      alert.classList.add('shown')
+      pre.innerHTML = JSON.stringify(detail, null, 2)
+    }
+
+    const onEvent = async e => {
+      await copyToClipboard(e)
+      await log(e)
+    }
+    picker.addEventListener('emoji-click-sync', onEvent)
     picker.addEventListener('skin-tone-change', onEvent)
 
     $$('input[name=darkmode]').forEach(input => {

--- a/docs/index.html
+++ b/docs/index.html
@@ -298,6 +298,7 @@
     const copyToClipboard = async e => {
       // fun workaround for a safari bug: https://github.com/nolanlawson/emoji-picker-element/issues/281
       // use emoji-click-sync and then write the promise to the navigator.clipboard to avoid a NotAllowedError
+      // normal usage is to use the emoji-click event instead
       try {
         await navigator.clipboard.write([new ClipboardItem({
           'text/plain': e.detail.then(({ unicode }) => unicode),
@@ -315,12 +316,14 @@
       pre.innerHTML = JSON.stringify(detail, null, 2)
     }
 
-    const onEvent = async e => {
+    picker.addEventListener('emoji-click-sync', async e => {
       await copyToClipboard(e)
       await log(e)
-    }
-    picker.addEventListener('emoji-click-sync', onEvent)
-    picker.addEventListener('skin-tone-change', onEvent)
+    })
+    picker.addEventListener('skin-tone-change', async e => {
+      summary.textContent = 'Skin tone changed! Details:'
+      await log(e)
+    })
 
     $$('input[name=darkmode]').forEach(input => {
       input.addEventListener('change', e => {

--- a/shared.d.ts
+++ b/shared.d.ts
@@ -78,11 +78,15 @@ declare type Modify<T, R> = Omit<T, keyof R> & R;
 export declare type EmojiClickEvent = Modify<UIEvent, {
     detail: EmojiClickEventDetail;
 }>;
+export declare type EmojiClickSyncEvent = Modify<UIEvent, {
+    detail: Promise<EmojiClickEventDetail>;
+}>;
 export declare type SkinToneChangeEvent = Modify<UIEvent, {
     detail: SkinToneChangeEventDetail;
 }>;
 export interface EmojiPickerEventMap {
     "emoji-click": EmojiClickEvent;
+    "emoji-click-sync": EmojiClickSyncEvent;
     "skin-tone-change": SkinToneChangeEvent;
 }
 export interface CustomEmoji {

--- a/test/spec/picker/Picker.test.js
+++ b/test/spec/picker/Picker.test.js
@@ -231,98 +231,100 @@ describe('Picker tests', () => {
       .toHaveLength(truncatedEmoji.filter(_ => _.group === 9).length))
   })
 
-  test('click emoji and get an event', async () => {
-    let emoji
-    picker.addEventListener('emoji-click', event => {
-      emoji = event.detail
+  for (const sync of [false, true]) {
+    test(`click emoji and get an event - ${sync ? 'sync' : 'async'}`, async () => {
+      let emoji
+      picker.addEventListener(sync ? 'emoji-click-sync' : 'emoji-click', async event => {
+        emoji = sync ? await event.detail : event.detail
+      })
+
+      getByRole('menuitem', { name: /😀/ }).click()
+      await waitFor(() => checkEmojiEquals(emoji, {
+        emoji: {
+          annotation: 'grinning face',
+          group: 0,
+          shortcodes: ['grinning', 'grinning_face'],
+          tags: [
+            'cheerful',
+            'cheery',
+            'face',
+            'grin',
+            'grinning',
+            'happy',
+            'laugh',
+            'nice',
+            'smile',
+            'smiling',
+            'teeth'
+
+          ],
+          unicode: '😀',
+          version: 1
+        },
+        skinTone: 0,
+        unicode: '😀'
+      }))
+
+      // choose a skin tone and then click an emoji where it would apply
+      getByRole('button', { name: /Choose a skin tone/ }).click()
+      await waitFor(() => expect(getByRole('option', { name: /Medium-Dark/ })).toBeVisible())
+      getByRole('option', { name: /Medium-Dark/ }).click()
+      await waitFor(
+        () => expect(getByRole('button', { name: 'Choose a skin tone (currently Medium-Dark)' })).toBeVisible()
+      )
+      getByRole('tab', { name: /People/ }).click()
+      await waitFor(() => expect(getByRole('menuitem', { name: /👍/ })).toBeVisible())
+      getByRole('menuitem', { name: /👍/ }).click()
+      await waitFor(() => checkEmojiEquals(emoji, {
+        emoji: {
+          annotation: 'thumbs up',
+          group: 1,
+          shortcodes: ['+1', 'thumbsup', 'yes'],
+          tags: ['+1', 'good', 'hand', 'like', 'thumb', 'up', 'yes'],
+          unicode: '👍️',
+          version: 0.6,
+          skins: [
+            { tone: 1, unicode: '👍🏻', version: 1 },
+            { tone: 2, unicode: '👍🏼', version: 1 },
+            { tone: 3, unicode: '👍🏽', version: 1 },
+            { tone: 4, unicode: '👍🏾', version: 1 },
+            { tone: 5, unicode: '👍🏿', version: 1 }
+          ]
+        },
+        skinTone: 4,
+        unicode: '👍🏾'
+      }))
+
+      // then click one that has no skins
+      getByRole('tab', { name: /Smileys/ }).click()
+      await waitFor(() => expect(getByRole('menuitem', { name: /😀/ })).toBeVisible())
+      getByRole('menuitem', { name: /😀/ }).click()
+      await waitFor(() => checkEmojiEquals(emoji, {
+        emoji: {
+          annotation: 'grinning face',
+          group: 0,
+          shortcodes: ['grinning', 'grinning_face'],
+          tags: [
+            'cheerful',
+            'cheery',
+            'face',
+            'grin',
+            'grinning',
+            'happy',
+            'laugh',
+            'nice',
+            'smile',
+            'smiling',
+            'teeth'
+          ],
+          unicode: '😀',
+          version: 1
+        },
+        skinTone: 4,
+        unicode: '😀'
+      }))
     })
-
-    getByRole('menuitem', { name: /😀/ }).click()
-    await waitFor(() => checkEmojiEquals(emoji, {
-      emoji: {
-        annotation: 'grinning face',
-        group: 0,
-        shortcodes: ['grinning', 'grinning_face'],
-        tags: [
-          'cheerful',
-          'cheery',
-          'face',
-          'grin',
-          'grinning',
-          'happy',
-          'laugh',
-          'nice',
-          'smile',
-          'smiling',
-          'teeth'
-
-        ],
-        unicode: '😀',
-        version: 1
-      },
-      skinTone: 0,
-      unicode: '😀'
-    }))
-
-    // choose a skin tone and then click an emoji where it would apply
-    getByRole('button', { name: /Choose a skin tone/ }).click()
-    await waitFor(() => expect(getByRole('option', { name: /Medium-Dark/ })).toBeVisible())
-    getByRole('option', { name: /Medium-Dark/ }).click()
-    await waitFor(
-      () => expect(getByRole('button', { name: 'Choose a skin tone (currently Medium-Dark)' })).toBeVisible()
-    )
-    getByRole('tab', { name: /People/ }).click()
-    await waitFor(() => expect(getByRole('menuitem', { name: /👍/ })).toBeVisible())
-    getByRole('menuitem', { name: /👍/ }).click()
-    await waitFor(() => checkEmojiEquals(emoji, {
-      emoji: {
-        annotation: 'thumbs up',
-        group: 1,
-        shortcodes: ['+1', 'thumbsup', 'yes'],
-        tags: ['+1', 'good', 'hand', 'like', 'thumb', 'up', 'yes'],
-        unicode: '👍️',
-        version: 0.6,
-        skins: [
-          { tone: 1, unicode: '👍🏻', version: 1 },
-          { tone: 2, unicode: '👍🏼', version: 1 },
-          { tone: 3, unicode: '👍🏽', version: 1 },
-          { tone: 4, unicode: '👍🏾', version: 1 },
-          { tone: 5, unicode: '👍🏿', version: 1 }
-        ]
-      },
-      skinTone: 4,
-      unicode: '👍🏾'
-    }))
-
-    // then click one that has no skins
-    getByRole('tab', { name: /Smileys/ }).click()
-    await waitFor(() => expect(getByRole('menuitem', { name: /😀/ })).toBeVisible())
-    getByRole('menuitem', { name: /😀/ }).click()
-    await waitFor(() => checkEmojiEquals(emoji, {
-      emoji: {
-        annotation: 'grinning face',
-        group: 0,
-        shortcodes: ['grinning', 'grinning_face'],
-        tags: [
-          'cheerful',
-          'cheery',
-          'face',
-          'grin',
-          'grinning',
-          'happy',
-          'laugh',
-          'nice',
-          'smile',
-          'smiling',
-          'teeth'
-        ],
-        unicode: '😀',
-        version: 1
-      },
-      skinTone: 4,
-      unicode: '😀'
-    }))
-  })
+  }
 
   test('press up/down on search input', async () => {
     type(getByRole('combobox'), 'monk')


### PR DESCRIPTION
Fixes #281

I really don't like adding additional API surface just to work around a Safari bug, but even if WebKit fixes it tomorrow, there will be old versions of Safari floating around for ages. 

Adds a new event, `emoji-click-sync`, which does the same thing as `emoji-click` but is synchronous and its `event.detail` is a promise for the same `detail` object in the non-sync version.