### PR TITLE
docs: update jsdelivr url

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <link rel="modulepreload" href="https://cdn.jsdelivr.net/npm/emoji-picker-element@^1/picker.js">
-  <link rel="modulepreload" href="https://cdn.jsdelivr.net/npm/emoji-picker-element@^1/database.js">
+  <link rel="modulepreload" href="https://cdn.jsdelivr.net/npm/emoji-picker-element@^1.27/picker.js">
+  <link rel="modulepreload" href="https://cdn.jsdelivr.net/npm/emoji-picker-element@^1.27/database.js">
   <link rel="icon" href="./icon.svg">
   <meta charset="UTF-8">
   <link rel="manifest" href="./manifest.json">
@@ -223,8 +223,8 @@
     <p><a href="https://github.blog/wp-content/uploads/2008/12/forkme_right_gray_6d6d6d.png?resize=149%2C149">Source code</a></p>
 </footer>
 <script type="module">
-  import 'https://cdn.jsdelivr.net/npm/emoji-picker-element@^1/picker.js'
-  import 'https://cdn.jsdelivr.net/npm/emoji-picker-element@^1/database.js' // avoid extra round-trip
+  import 'https://cdn.jsdelivr.net/npm/emoji-picker-element@^1.27/picker.js'
+  import 'https://cdn.jsdelivr.net/npm/emoji-picker-element@^1.27/database.js' // avoid extra round-trip
 
   const $ = document.querySelector.bind(document)
   const $$ = _ => Array.from(document.querySelectorAll(_))


### PR DESCRIPTION
Ensure the docs site gets an up-to-date version of the picker due to caching.