### PR TITLE
test: test abnormal IndexedDB close event

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "emoji-picker-element-data": "^1.7.2",
     "emojibase-data": "^5.1.1",
     "express": "^5.1.0",
-    "fake-indexeddb": "^6.0.1",
+    "fake-indexeddb": "^6.2.2",
     "fast-glob": "^3.3.3",
     "fetch-mock": "^11.1.5",
     "flat-color-icons": "^1.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,8 +69,8 @@ importers:
         specifier: ^5.1.0
         version: 5.1.0
       fake-indexeddb:
-        specifier: ^6.0.1
-        version: 6.0.1
+        specifier: ^6.2.2
+        version: 6.2.2
       fast-glob:
         specifier: ^3.3.3
         version: 3.3.3
@@ -1960,8 +1960,8 @@ packages:
     engines: {node: '>= 10.17.0'}
     hasBin: true
 
-  fake-indexeddb@6.0.1:
-    resolution: {integrity: sha512-He2AjQGHe46svIFq5+L2Nx/eHDTI1oKgoevBP+TthnjymXiKkeJQ3+ITeWey99Y5+2OaPFbI1qEsx/5RsGtWnQ==}
+  fake-indexeddb@6.2.2:
+    resolution: {integrity: sha512-SGbf7fzjeHz3+12NO1dYigcYn4ivviaeULV5yY5rdGihBvvgwMds4r4UBbNIUMwkze57KTDm32rq3j1Az8mzEw==}
     engines: {node: '>=18'}
 
   fast-deep-equal@3.1.3:
@@ -6367,7 +6367,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fake-indexeddb@6.0.1: {}
+  fake-indexeddb@6.2.2: {}
 
   fast-deep-equal@3.1.3: {}
 

--- a/src/database/databaseLifecycle.js
+++ b/src/database/databaseLifecycle.js
@@ -34,8 +34,6 @@ async function createDatabase (dbName) {
   // Handle abnormal closes, e.g. "delete database" in chrome dev tools.
   // No need for removeEventListener, because once the DB can no longer
   // fire "close" events, it will auto-GC.
-  // Unfortunately cannot test in fakeIndexedDB: https://github.com/dumbmatter/fakeIndexedDB/issues/50
-  /* istanbul ignore next */
   db.onclose = () => closeDatabase(dbName)
   performance.measure('createDatabase', 'createDatabase')
   return db

--- a/test/spec/database/Database.test.js
+++ b/test/spec/database/Database.test.js
@@ -15,6 +15,7 @@ import {
 } from '../shared'
 import trimEmojiData from '../../../src/trimEmojiData'
 import { mockFetch, mockGetAndHead } from '../mockFetch.js'
+import { forceCloseDatabase } from 'fake-indexeddb'
 
 describe('database tests', () => {
   beforeEach(basicBeforeEach)
@@ -298,6 +299,19 @@ describe('database tests', () => {
     await db.ready()
 
     expect((await db.getEmojiBySearchQuery('monkey'))[0].unicode).toBe('🐵')
+
+    await db.delete()
+  })
+
+  test('abnormal indexeddb close event', async () => {
+    const dataSource = ALL_EMOJI
+    const db = new Database({ dataSource })
+    await db.ready()
+
+    // should be handled gracefully by 'close' event listener
+    forceCloseDatabase(db._db)
+
+    await tick(20)
 
     await db.delete()
   })


### PR DESCRIPTION
This is just basically to increase our test coverage and to take advantage of a new fake-indexeddb feature: https://github.com/dumbmatter/fakeIndexedDB/pull/126